### PR TITLE
Add command auto-completer and unit tests for TUI commands

### DIFF
--- a/app/src/main/java/com/smartpet/todo/tui/CommandAutoCompleter.kt
+++ b/app/src/main/java/com/smartpet/todo/tui/CommandAutoCompleter.kt
@@ -1,0 +1,167 @@
+package com.smartpet.todo.tui
+
+private val ROOT_COMMANDS = listOf(":help", ":agents", ":clear", ":save", ":exit", ":mode", ":use", ":include", ":model")
+private val MODE_VALUES = listOf("auto", "compare", "single")
+
+private val COMMAND_HINTS = mapOf(
+    ":mode" to ":mode <auto|compare|single>",
+    ":use" to ":use <agent>",
+    ":model" to ":model <agent>",
+    ":include" to ":include <agent[,agent,...]>"
+)
+
+data class CompletionResult(
+    val candidates: List<String>,
+    val replacementStart: Int,
+    val replacementEnd: Int,
+    val hint: String? = null,
+    val didYouMean: String? = null
+)
+
+object CommandAutoCompleter {
+    fun complete(
+        input: String,
+        cursor: Int = input.length,
+        registeredAgents: List<String> = emptyList(),
+        alreadyIncludedAgents: List<String> = emptyList()
+    ): CompletionResult {
+        val safeCursor = cursor.coerceIn(0, input.length)
+        val head = input.substring(0, safeCursor)
+
+        if (!head.startsWith(':')) {
+            return emptyAtCursor(safeCursor)
+        }
+
+        val firstSpace = head.indexOf(' ')
+        if (firstSpace == -1) {
+            val candidates = ROOT_COMMANDS.filter { it.startsWith(head) }
+            val didYouMean = if (candidates.isEmpty()) closestCommand(head) else null
+            return CompletionResult(
+                candidates = candidates,
+                replacementStart = 0,
+                replacementEnd = safeCursor,
+                didYouMean = didYouMean
+            )
+        }
+
+        val command = head.substring(0, firstSpace)
+        val args = input.substring(firstSpace + 1)
+        val relativeCursor = (safeCursor - (firstSpace + 1)).coerceAtLeast(0)
+
+        return when (command) {
+            ":mode" -> completeSingleToken(
+                args = args,
+                argsOffset = firstSpace + 1,
+                cursorInArgs = relativeCursor,
+                candidates = MODE_VALUES,
+                hint = COMMAND_HINTS[command]
+            )
+
+            ":use", ":model" -> completeSingleToken(
+                args = args,
+                argsOffset = firstSpace + 1,
+                cursorInArgs = relativeCursor,
+                candidates = registeredAgents.distinct().sorted(),
+                hint = COMMAND_HINTS[command]
+            )
+
+            ":include" -> completeCommaSeparatedAgents(
+                args = args,
+                argsOffset = firstSpace + 1,
+                cursorInArgs = relativeCursor,
+                registeredAgents = registeredAgents,
+                alreadyIncludedAgents = alreadyIncludedAgents,
+                hint = COMMAND_HINTS[command]
+            )
+
+            else -> emptyAtCursor(safeCursor, didYouMean = closestCommand(command))
+        }
+    }
+
+    private fun completeSingleToken(
+        args: String,
+        argsOffset: Int,
+        cursorInArgs: Int,
+        candidates: List<String>,
+        hint: String?
+    ): CompletionResult {
+        val safeCursor = cursorInArgs.coerceIn(0, args.length)
+        val tokenStart = args.lastIndexOf(' ', startIndex = safeCursor - 1).let { if (it == -1) 0 else it + 1 }
+        val tokenEnd = args.indexOf(' ', startIndex = safeCursor).let { if (it == -1) args.length else it }
+        val token = args.substring(tokenStart, safeCursor)
+
+        return CompletionResult(
+            candidates = candidates.filter { it.startsWith(token) },
+            replacementStart = argsOffset + tokenStart,
+            replacementEnd = argsOffset + tokenEnd,
+            hint = hint
+        )
+    }
+
+    private fun completeCommaSeparatedAgents(
+        args: String,
+        argsOffset: Int,
+        cursorInArgs: Int,
+        registeredAgents: List<String>,
+        alreadyIncludedAgents: List<String>,
+        hint: String?
+    ): CompletionResult {
+        val safeCursor = cursorInArgs.coerceIn(0, args.length)
+        val beforeCursor = args.substring(0, safeCursor)
+        val tokenStart = beforeCursor.lastIndexOf(',').let { if (it == -1) 0 else it + 1 }
+        val tokenEnd = args.indexOf(',', startIndex = safeCursor).let { if (it == -1) args.length else it }
+
+        val beforeTokenList = args.substring(0, tokenStart)
+            .split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        val used = (beforeTokenList + alreadyIncludedAgents).toSet()
+        val allowedCandidates = registeredAgents.distinct().filterNot { it in used }.sorted()
+
+        val rawToken = args.substring(tokenStart, safeCursor)
+        val trimmedToken = rawToken.trimStart()
+        val leadingWhitespace = rawToken.length - trimmedToken.length
+
+        return CompletionResult(
+            candidates = allowedCandidates.filter { it.startsWith(trimmedToken) },
+            replacementStart = argsOffset + tokenStart + leadingWhitespace,
+            replacementEnd = argsOffset + tokenEnd,
+            hint = hint
+        )
+    }
+
+    private fun emptyAtCursor(cursor: Int, didYouMean: String? = null): CompletionResult =
+        CompletionResult(emptyList(), cursor, cursor, didYouMean = didYouMean)
+
+    private fun closestCommand(rawCommand: String): String? {
+        return ROOT_COMMANDS
+            .map { candidate -> candidate to levenshtein(rawCommand, candidate) }
+            .minByOrNull { it.second }
+            ?.takeIf { (_, distance) -> distance <= 3 }
+            ?.first
+    }
+
+    private fun levenshtein(left: String, right: String): Int {
+        if (left == right) return 0
+        if (left.isEmpty()) return right.length
+        if (right.isEmpty()) return left.length
+
+        val distances = IntArray(right.length + 1) { it }
+        for (i in 1..left.length) {
+            var previousDiagonal = distances[0]
+            distances[0] = i
+            for (j in 1..right.length) {
+                val temp = distances[j]
+                val cost = if (left[i - 1] == right[j - 1]) 0 else 1
+                distances[j] = minOf(
+                    distances[j] + 1,
+                    distances[j - 1] + 1,
+                    previousDiagonal + cost
+                )
+                previousDiagonal = temp
+            }
+        }
+        return distances[right.length]
+    }
+}

--- a/app/src/test/java/com/smartpet/todo/tui/CommandAutoCompleterTest.kt
+++ b/app/src/test/java/com/smartpet/todo/tui/CommandAutoCompleterTest.kt
@@ -1,0 +1,84 @@
+package com.smartpet.todo.tui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CommandAutoCompleterTest {
+
+    @Test
+    fun `completes root command prefix`() {
+        val result = CommandAutoCompleter.complete(":ag")
+
+        assertEquals(listOf(":agents"), result.candidates)
+        assertEquals(0, result.replacementStart)
+        assertEquals(3, result.replacementEnd)
+    }
+
+    @Test
+    fun `completes mode argument`() {
+        val result = CommandAutoCompleter.complete(":mode c")
+
+        assertEquals(listOf("compare"), result.candidates)
+        assertEquals(6, result.replacementStart)
+        assertEquals(7, result.replacementEnd)
+        assertEquals(":mode <auto|compare|single>", result.hint)
+    }
+
+    @Test
+    fun `completes use argument from registered agents`() {
+        val result = CommandAutoCompleter.complete(
+            input = ":use co",
+            registeredAgents = listOf("codex", "gemini")
+        )
+
+        assertEquals(listOf("codex"), result.candidates)
+        assertEquals(":use <agent>", result.hint)
+    }
+
+    @Test
+    fun `completes include argument token by token and excludes already selected`() {
+        val result = CommandAutoCompleter.complete(
+            input = ":include codex,ge",
+            registeredAgents = listOf("codex", "gemini", "claude")
+        )
+
+        assertEquals(listOf("gemini"), result.candidates)
+    }
+
+    @Test
+    fun `completes at cursor position inside argument token`() {
+        val input = ":mode compare"
+        val cursor = input.indexOf("par")
+
+        val result = CommandAutoCompleter.complete(input = input, cursor = cursor)
+
+        assertEquals(listOf("compare"), result.candidates)
+        assertEquals(6, result.replacementStart)
+        assertEquals(input.length, result.replacementEnd)
+    }
+
+    @Test
+    fun `returns empty candidates for use when no agents are registered`() {
+        val result = CommandAutoCompleter.complete(":use c", registeredAgents = emptyList())
+
+        assertTrue(result.candidates.isEmpty())
+        assertEquals(":use <agent>", result.hint)
+    }
+
+    @Test
+    fun `returns did you mean for unknown command`() {
+        val result = CommandAutoCompleter.complete(":agnts")
+
+        assertEquals(":agents", result.didYouMean)
+    }
+
+    @Test
+    fun `returns empty candidates for non command input`() {
+        val result = CommandAutoCompleter.complete("hello")
+
+        assertTrue(result.candidates.isEmpty())
+        assertNull(result.didYouMean)
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide interactive auto-completion for TUI commands and arguments to improve CLI usability.
- Handle single-token completions, comma-separated agent lists, and suggest closest root commands for typos.

### Description

- Introduce `CommandAutoCompleter` with `complete` API and `CompletionResult` data class to compute candidates, replacement ranges, hints, and "did you mean" suggestions.
- Implement root command completion, `:mode` value completion, `:use`/`:model` completion from a `registeredAgents` list, and `:include` multi-agent comma-separated completion that excludes already selected agents.
- Add Levenshtein distance-based `closestCommand` suggestion and robust token start/end calculations with cursor-aware behavior.
- Add unit tests in `CommandAutoCompleterTest` covering root command prefixing, mode argument completion, agent lookups, comma-separated inclusion behavior, cursor-positioned completion, empty-agent handling, typo suggestions, and non-command input.

### Testing

- Added JUnit tests in `app/src/test/java/com/smartpet/todo/tui/CommandAutoCompleterTest.kt` that exercise the completion scenarios described above.
- Ran the test suite for the new tests and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a779cec3248333b7dc37d11f2dd831)