### PR TITLE
feat: add punishment system and accountability flows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,20 @@
+name: Android CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Unit tests
+        run: ./gradlew test
+      - name: Assemble debug
+        run: ./gradlew :app:assembleDebug

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,49 @@
-# SmartPetTodo - Agent Guidelines
+# SmartPetTodo - Agent Guide
 
-## Default Delegation (Sub-Agents)
-- Use sub-agents automatically when it reduces wall-clock time without increasing merge/conflict risk.
-- Prefer `explorer` for read-only codebase mapping, locating files, and root-cause analysis.
-- Prefer `worker` for isolated implementation tasks with explicit file ownership.
+## 프로젝트 목적
+- webhook 기반 할 일 앱과 Android 벌칙 시스템을 유지보수합니다.
+- 원격 task CRUD와 로컬 벌칙 sidecar 저장을 분리합니다.
 
-## When To Spawn
-- The task has parallelizable subtasks (e.g., investigate + implement + verify).
-- The change spans multiple layers/modules where discovery can be delegated safely.
-- Builds/tests/lint are expected to take long enough to overlap with other work.
-
-## Coordination Rules
-- Always assign each sub-agent a strict scope (files/modules + a concrete goal).
-- Never have multiple agents edit the same file at the same time.
-- The main agent owns final integration, conflict resolution, and end-to-end verification.
-
-## Project Commands (Android/Gradle)
+## 빠른 시작 명령
 - `./gradlew test`
 - `./gradlew :app:assembleDebug`
-- `./gradlew lint` (if configured)
+- `./gradlew connectedAndroidTest`
+
+## 기본 작업 순서
+1. `README.md`, `AGENTS.md`, `docs/changes/`, `docs/runbooks/`를 읽습니다.
+2. `./gradlew test`와 `./gradlew :app:assembleDebug` 기준선을 확인합니다.
+3. 원격 task payload와 로컬 penalty sidecar를 섞지 않습니다.
+4. UI, penalty engine, Kakao integration, docs/CI를 같이 갱신합니다.
+
+## 완료 조건
+- `./gradlew test` 통과
+- `./gradlew :app:assembleDebug` 통과
+- 관련 docs/README 갱신
+- Device Owner / Kakao 전제 조건을 문서에 명시
+
+## 코드 스타일 원칙
+- Kotlin 17
+- 벌칙 로직은 `penalty/`에 모읍니다.
+- Kakao 알림/세션 로직은 `kakao/`에 모읍니다.
+- Activity/UI에서 직접 정책 판단하지 말고 selector/enforcer를 경유합니다.
+
+## 민감 경로
+- `app/src/main/java/com/smartpet/todo/data/RemoteStorage.kt`: webhook 계약 변경 금지
+- `app/src/main/java/com/smartpet/todo/admin/`: Device Owner / lock task
+- `app/src/main/java/com/smartpet/todo/kakao/`: 알림 리스너 권한 전제
+- `app/src/main/java/com/smartpet/todo/ui/OverdueVerificationActivity.kt`: 사용자가 쉽게 탈출할 수 없게 유지
+
+## 작업 전 체크리스트
+- 원격 API URL 확인
+- 에뮬레이터/디바이스 상태 확인
+- 알림 접근 / Device Owner 전제 조건 확인
+
+## 작업 후 체크리스트
+- 테스트/빌드 결과 기록
+- README, docs/changes, runbook 반영
+- 미해결 리스크 명시
+
+## 절대 금지
+- 벌칙 메타데이터를 원격 task payload에 몰래 섞지 말 것
+- Device Owner 준비 없이 잠금이 되는 것처럼 말하지 말 것
+- 제3자 괴롭힘 자동화를 추가하지 말 것

--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# 마더 Android
+
+`마더`는 마감이 지난 할 일을 단순 알림으로 끝내지 않고, 사용자가 미이행 비용을 직접 설정해 목표 달성을 돕는 Android 앱입니다.
+
+## 핵심 기능
+
+- webhook 기반 할 일 CRUD
+- task별 벌칙 선택: 자동 추천 / 수동 지정
+- 벌칙 종류
+  - 인증 고정
+  - 앱 고정 잠금(lock task, 공식 kiosk 모드가 준비된 경우만)
+  - 책임 파트너 전화
+  - 책임 파트너 KakaoTalk 메시지
+- overdue 시 punishment trigger + 사진 인증 gate
+- Kakao 알림 세션 캐시 기반 책임 메시지 전송
+
+## 기술 스택
+
+- Kotlin
+- Android SDK 34
+- Jetpack Compose
+- Material 3
+- Gradle Kotlin DSL
+
+## 요구 환경
+
+- Android Studio 또는 JDK 17 + Android SDK
+- `./gradlew` 실행 가능 환경
+- 선택 사항
+  - `MOTHER_TASKS_BASE_URL`
+  - `MOTHER_VERIFY_URL`
+
+## 설치 및 실행
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+생성 APK:
+
+- `app/build/outputs/apk/debug/app-debug.apk`
+
+## 테스트
+
+```bash
+./gradlew test
+./gradlew :app:assembleDebug
+./gradlew connectedAndroidTest
+```
+
+`connectedAndroidTest`는 온라인 에뮬레이터/디바이스가 필요합니다.
+
+## 환경 변수 / .env
+
+`.env.example` 예시:
+
+```env
+MOTHER_TASKS_BASE_URL=https://heodongun.com/webhook/mother/tasks
+MOTHER_VERIFY_URL=https://heodongun.com/webhook/mother/verify-photo
+```
+
+## 벌칙 설정 요약
+
+- 연락형 벌칙은 동의한 책임 파트너에게만 사용합니다.
+- Kakao 벌칙은 앱의 알림 접근 권한과 최근 알림 세션이 필요합니다.
+- 앱 고정 잠금은 Device Owner + lock task allowlist가 준비된 경우에만 동작합니다.
+- 코딩/공부처럼 디바이스가 필요한 목표는 자동으로 잠금형 벌칙을 피합니다.
+
+## 빠른 개발 명령
+
+```bash
+./gradlew test
+./gradlew :app:assembleDebug
+./gradlew connectedAndroidTest
+```
+
+## 폴더 구조
+
+```text
+app/src/main/java/com/smartpet/todo/
+  admin/      # device admin, lock task
+  kakao/      # Kakao notification listener/session sender
+  penalty/    # local sidecar store, selector, enforcer
+  ui/         # Compose screen/activity
+  viewmodel/  # Task + penalty 상태 조합
+```
+
+## 알려진 제한 사항
+
+- 원격 webhook은 task 본문만 저장하고, 벌칙 메타데이터는 기기 로컬에만 저장됩니다.
+- Kakao 벌칙은 최근에 알림을 받은 방 세션이 있어야 바로 전송됩니다.
+- Device Owner provisioning 없이 앱 잠금 벌칙은 준비 상태만 표시되고 실행되지 않습니다.
+
+## 문서
+
+- 변경 기록: `docs/changes/`
+- lock task 준비: `docs/runbooks/android-device-owner-lock-task.md`

--- a/app/src/androidTest/java/com/smartpet/todo/ui/TaskListScreenTest.kt
+++ b/app/src/androidTest/java/com/smartpet/todo/ui/TaskListScreenTest.kt
@@ -3,7 +3,9 @@ package com.smartpet.todo.ui
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -12,6 +14,7 @@ import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import com.smartpet.todo.data.Task
 import com.smartpet.todo.data.TaskPriority
+import com.smartpet.todo.penalty.PenaltySettings
 import com.smartpet.todo.viewmodel.TaskUiState
 import org.junit.Rule
 import org.junit.Test
@@ -27,8 +30,9 @@ class TaskListScreenTest {
             SmartPetTodoTheme {
                 TaskListScreen(
                     uiState = TaskUiState(tasks = emptyList(), isLoading = false),
-                    onAddTask = { _, _, _, _, _, _ -> },
-                    onUpdateTask = { },
+                    onAddTask = { _, _, _, _, _, _, _ -> },
+                    onUpdateTask = { _, _ -> },
+                    onSavePenaltySettings = { },
                     onToggleComplete = { },
                     onDeleteTask = { },
                     onRestoreTask = { },
@@ -51,7 +55,7 @@ class TaskListScreenTest {
             SmartPetTodoTheme {
                 TaskListScreen(
                     uiState = uiState,
-                    onAddTask = { title, description, dueDate, priority, maxLevel, est ->
+                    onAddTask = { title, description, dueDate, priority, maxLevel, est, _ ->
                         tasks.add(
                             Task(
                                 title = title,
@@ -63,10 +67,11 @@ class TaskListScreenTest {
                             )
                         )
                     },
-                    onUpdateTask = { updated ->
+                    onUpdateTask = { updated, _ ->
                         val idx = tasks.indexOfFirst { it.id == updated.id }
                         if (idx != -1) tasks[idx] = updated
                     },
+                    onSavePenaltySettings = { },
                     onToggleComplete = { id ->
                         val idx = tasks.indexOfFirst { it.id == id }
                         if (idx != -1) {
@@ -74,9 +79,7 @@ class TaskListScreenTest {
                             tasks[idx] = t.copy(isCompleted = !t.isCompleted)
                         }
                     },
-                    onDeleteTask = { id ->
-                        tasks.removeAll { it.id == id }
-                    },
+                    onDeleteTask = { id -> tasks.removeAll { it.id == id } },
                     onRestoreTask = { task ->
                         val idx = tasks.indexOfFirst { it.id == task.id }
                         if (idx == -1) tasks.add(task) else tasks[idx] = task
@@ -90,7 +93,6 @@ class TaskListScreenTest {
         composeRule.onNodeWithTag("task_editor_dialog").assertExists()
         composeRule.onNodeWithTag("task_editor_title").performTextInput("운동")
         composeRule.onNodeWithTag("task_editor_save").performClick()
-
         composeRule.onNodeWithText("운동").assertExists()
     }
 
@@ -102,18 +104,20 @@ class TaskListScreenTest {
                     Task(id = "idA", title = "A", priority = TaskPriority.NORMAL, maxEnforcementLevel = 3)
                 )
             }
+            var settings by remember { mutableStateOf(PenaltySettings()) }
             val uiState by remember {
-                derivedStateOf { TaskUiState(tasks = tasks.toList(), isLoading = false) }
+                derivedStateOf { TaskUiState(tasks = tasks.toList(), isLoading = false, penaltySettings = settings) }
             }
 
             SmartPetTodoTheme {
                 TaskListScreen(
                     uiState = uiState,
-                    onAddTask = { _, _, _, _, _, _ -> },
-                    onUpdateTask = { updated ->
+                    onAddTask = { _, _, _, _, _, _, _ -> },
+                    onUpdateTask = { updated, _ ->
                         val idx = tasks.indexOfFirst { it.id == updated.id }
                         if (idx != -1) tasks[idx] = updated
                     },
+                    onSavePenaltySettings = { settings = it },
                     onToggleComplete = { },
                     onDeleteTask = { },
                     onRestoreTask = { },
@@ -122,7 +126,6 @@ class TaskListScreenTest {
             }
         }
 
-        // Open editor
         composeRule.onNodeWithTag("task_card_idA").performClick()
         composeRule.onNodeWithTag("task_editor_title").performTextClearance()
         composeRule.onNodeWithTag("task_editor_title").performTextInput("B")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
     <application
         android:allowBackup="true"
@@ -24,19 +26,42 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-    
+
         <activity
             android:name=".ui.OverdueVerificationActivity"
+            android:excludeFromRecents="true"
             android:exported="false"
             android:showOnLockScreen="true"
-            android:turnScreenOn="true"
-            android:excludeFromRecents="true"
-            android:theme="@style/Theme.SmartPetTodo" />
+            android:theme="@style/Theme.SmartPetTodo"
+            android:turnScreenOn="true" />
 
         <receiver
             android:name=".alarm.OverdueAlarmReceiver"
             android:exported="false" />
 
+        <receiver
+            android:name=".admin.MotherDeviceAdminReceiver"
+            android:description="@string/app_name"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/mother_device_admin_receiver" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name=".kakao.KakaoNotificationListenerService"
+            android:exported="false"
+            android:label="카카오 알림 세션 캐시"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/smartpet/todo/MainActivity.kt
+++ b/app/src/main/java/com/smartpet/todo/MainActivity.kt
@@ -2,22 +2,23 @@ package com.smartpet.todo
 
 import android.Manifest
 import android.content.pm.PackageManager
-import android.os.Bundle
 import android.os.Build
+import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
-import com.smartpet.todo.ui.TaskListScreen
 import com.smartpet.todo.ui.SmartPetTodoTheme
+import com.smartpet.todo.ui.TaskListScreen
 import com.smartpet.todo.viewmodel.TaskViewModel
 
 class MainActivity : ComponentActivity() {
@@ -32,25 +33,21 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        
+
         setContent {
             SmartPetTodoTheme {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
-                    color = androidx.compose.material3.MaterialTheme.colorScheme.background
+                    color = MaterialTheme.colorScheme.background
                 ) {
                     val uiState by viewModel.uiState.collectAsState()
-                    
                     TaskListScreen(
                         uiState = uiState,
                         onAddTask = viewModel::addTask,
                         onUpdateTask = viewModel::updateTask,
-                        onToggleComplete = { taskId ->
-                            viewModel.toggleTaskCompletion(taskId)
-                        },
-                        onDeleteTask = { taskId ->
-                            viewModel.deleteTask(taskId)
-                        },
+                        onSavePenaltySettings = viewModel::savePenaltySettings,
+                        onToggleComplete = viewModel::toggleTaskCompletion,
+                        onDeleteTask = viewModel::deleteTask,
                         onRestoreTask = viewModel::restoreTask,
                         onRefresh = viewModel::refresh
                     )

--- a/app/src/main/java/com/smartpet/todo/admin/LockTaskController.kt
+++ b/app/src/main/java/com/smartpet/todo/admin/LockTaskController.kt
@@ -1,0 +1,44 @@
+package com.smartpet.todo.admin
+
+import android.app.Activity
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+
+data class LockTaskStatus(
+    val isDeviceOwnerApp: Boolean,
+    val isLockTaskPermitted: Boolean,
+    val adbProvisioningCommand: String
+)
+
+object LockTaskController {
+    fun status(context: Context): LockTaskStatus {
+        val dpm = context.getSystemService(DevicePolicyManager::class.java)
+        val isDeviceOwner = dpm?.isDeviceOwnerApp(context.packageName) == true
+        if (isDeviceOwner) {
+            runCatching {
+                dpm?.setLockTaskPackages(adminComponent(context), arrayOf(context.packageName))
+            }
+        }
+        return LockTaskStatus(
+            isDeviceOwnerApp = isDeviceOwner,
+            isLockTaskPermitted = dpm?.isLockTaskPermitted(context.packageName) == true,
+            adbProvisioningCommand = "adb shell dpm set-device-owner ${context.packageName}/${MotherDeviceAdminReceiver::class.java.name}"
+        )
+    }
+
+    fun startLockTaskIfPermitted(activity: Activity): Boolean {
+        return if (status(activity).isLockTaskPermitted) {
+            runCatching { activity.startLockTask() }.isSuccess
+        } else {
+            false
+        }
+    }
+
+    fun stopLockTaskSafely(activity: Activity) {
+        runCatching { activity.stopLockTask() }
+    }
+
+    private fun adminComponent(context: Context): ComponentName =
+        ComponentName(context, MotherDeviceAdminReceiver::class.java)
+}

--- a/app/src/main/java/com/smartpet/todo/admin/MotherDeviceAdminReceiver.kt
+++ b/app/src/main/java/com/smartpet/todo/admin/MotherDeviceAdminReceiver.kt
@@ -1,0 +1,16 @@
+package com.smartpet.todo.admin
+
+import android.app.admin.DeviceAdminReceiver
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+
+class MotherDeviceAdminReceiver : DeviceAdminReceiver() {
+    override fun onEnabled(context: Context, intent: Intent) {
+        Toast.makeText(context, "마더 기기 관리자 권한이 활성화됐어요.", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onDisabled(context: Context, intent: Intent) {
+        Toast.makeText(context, "마더 기기 관리자 권한이 해제됐어요.", Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/kakao/KakaoMessageSender.kt
+++ b/app/src/main/java/com/smartpet/todo/kakao/KakaoMessageSender.kt
@@ -1,0 +1,35 @@
+package com.smartpet.todo.kakao
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.app.RemoteInput
+
+class KakaoMessageSender(private val context: Context) {
+    data class SendResult(
+        val success: Boolean,
+        val message: String
+    )
+
+    fun send(roomName: String, message: String): SendResult {
+        val session = KakaoSessionManager.getSession(roomName)
+            ?: return SendResult(false, "최근에 받은 카카오 알림 세션이 없어 바로 전송할 수 없어요.")
+        val remoteInputs = session.action.remoteInputs
+        if (remoteInputs.isNullOrEmpty()) {
+            return SendResult(false, "이 채팅방 알림에는 답장 입력 필드가 없어요.")
+        }
+
+        return runCatching {
+            val remoteInput = remoteInputs.first()
+            val intent = Intent()
+            val bundle = Bundle().apply {
+                putCharSequence(remoteInput.resultKey, message)
+            }
+            RemoteInput.addResultsToIntent(arrayOf(remoteInput), intent, bundle)
+            session.action.actionIntent?.send(context, 0, intent) ?: error("pendingIntent missing")
+            SendResult(true, "카카오톡 책임 메시지를 보냈어요.")
+        }.getOrElse {
+            SendResult(false, "카카오톡 전송 실패: ${it.message ?: "알 수 없는 오류"}")
+        }
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/kakao/KakaoNotificationAccess.kt
+++ b/app/src/main/java/com/smartpet/todo/kakao/KakaoNotificationAccess.kt
@@ -1,0 +1,16 @@
+package com.smartpet.todo.kakao
+
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import androidx.core.app.NotificationManagerCompat
+
+object KakaoNotificationAccess {
+    fun isEnabled(context: Context): Boolean {
+        return NotificationManagerCompat.getEnabledListenerPackages(context).contains(context.packageName)
+    }
+
+    fun settingsIntent(): Intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/kakao/KakaoNotificationListenerService.kt
+++ b/app/src/main/java/com/smartpet/todo/kakao/KakaoNotificationListenerService.kt
@@ -1,0 +1,53 @@
+package com.smartpet.todo.kakao
+
+import android.app.Notification
+import android.os.Bundle
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+
+class KakaoNotificationListenerService : NotificationListenerService() {
+    private val processedNotifications = mutableMapOf<String, Long>()
+
+    override fun onNotificationPosted(sbn: StatusBarNotification) {
+        super.onNotificationPosted(sbn)
+        if (sbn.packageName != KAKAO_PACKAGE_NAME) return
+
+        val lastSeen = processedNotifications[sbn.key] ?: 0L
+        if (sbn.postTime <= lastSeen) return
+        processedNotifications[sbn.key] = sbn.postTime
+        if (processedNotifications.size > 200) {
+            processedNotifications.entries.minByOrNull { it.value }?.key?.let { processedNotifications.remove(it) }
+        }
+
+        runCatching {
+            val roomName = extractRoomName(sbn.notification) ?: return
+            KakaoSessionManager.bindSession(this, roomName, sbn.notification, sbn.packageName)
+        }.onFailure {
+            Log.e("MotherKakao", "카카오 알림 처리 실패", it)
+        }
+    }
+
+    private fun extractRoomName(notification: Notification): String? {
+        val extras = notification.extras ?: return null
+        val roomFromConversation = extras.getCharSequence(Notification.EXTRA_CONVERSATION_TITLE)?.toString()?.trim()
+        if (!roomFromConversation.isNullOrBlank()) return roomFromConversation
+
+        val messages = extras.getParcelableArray(Notification.EXTRA_MESSAGES)
+        if (!messages.isNullOrEmpty()) {
+            val last = messages.last()
+            if (last is Bundle) {
+                val sender = last.getCharSequence("sender")?.toString()?.trim()
+                if (!sender.isNullOrBlank()) return sender
+            }
+        }
+
+        return extras.getCharSequence(Notification.EXTRA_SUB_TEXT)?.toString()?.trim()
+            ?: extras.getCharSequence(Notification.EXTRA_SUMMARY_TEXT)?.toString()?.trim()
+            ?: extras.getCharSequence(Notification.EXTRA_TITLE)?.toString()?.trim()
+    }
+
+    companion object {
+        const val KAKAO_PACKAGE_NAME = "com.kakao.talk"
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/kakao/KakaoSessionManager.kt
+++ b/app/src/main/java/com/smartpet/todo/kakao/KakaoSessionManager.kt
@@ -1,0 +1,90 @@
+package com.smartpet.todo.kakao
+
+import android.app.Notification
+import android.content.Context
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import org.json.JSONObject
+
+object KakaoSessionManager {
+    private const val PREFS_NAME = "MotherKakaoSessions"
+    private const val KEY_ROOM_TIMES = "room_times"
+
+    private val sessionMap = mutableMapOf<String, CachedSession>()
+    private val roomLastSeen = mutableMapOf<String, Long>()
+    private var roomsLoaded = false
+
+    data class CachedSession(
+        val action: NotificationCompat.Action,
+        val packageName: String,
+        val updatedAt: Long = System.currentTimeMillis()
+    )
+
+    data class RoomEntry(
+        val name: String,
+        val lastSeen: Long,
+        val hasActiveSession: Boolean
+    )
+
+    fun bindSession(context: Context, room: String, notification: Notification, packageName: String) {
+        val action = findReplyAction(notification) ?: return
+        loadRooms(context)
+        sessionMap[room] = CachedSession(action = action, packageName = packageName)
+        roomLastSeen[room] = System.currentTimeMillis()
+        persistRooms(context)
+    }
+
+    fun getSession(room: String): CachedSession? = sessionMap[room]
+
+    fun getRegisteredRooms(context: Context): List<RoomEntry> {
+        loadRooms(context)
+        val names = (roomLastSeen.keys + sessionMap.keys).distinct().sortedBy { it.lowercase() }
+        return names.map { room ->
+            RoomEntry(
+                name = room,
+                lastSeen = roomLastSeen[room] ?: 0L,
+                hasActiveSession = sessionMap.containsKey(room)
+            )
+        }
+    }
+
+    fun findReplyAction(notification: Notification): NotificationCompat.Action? {
+        val wearableExtender = NotificationCompat.WearableExtender(notification)
+        wearableExtender.actions.firstOrNull { !it.remoteInputs.isNullOrEmpty() }?.let { return it }
+        for (index in 0 until NotificationCompat.getActionCount(notification)) {
+            val action = NotificationCompat.getAction(notification, index)
+            if (action != null && !action.remoteInputs.isNullOrEmpty()) return action
+        }
+        return null
+    }
+
+    private fun loadRooms(context: Context) {
+        if (roomsLoaded) return
+        roomsLoaded = true
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val jsonStr = prefs.getString(KEY_ROOM_TIMES, null) ?: return
+        runCatching {
+            val json = JSONObject(jsonStr)
+            val keys = json.keys()
+            while (keys.hasNext()) {
+                val key = keys.next()
+                roomLastSeen[key] = json.optLong(key, 0L)
+            }
+        }.onFailure {
+            Log.e("MotherKakao", "방 캐시 로드 실패", it)
+        }
+    }
+
+    private fun persistRooms(context: Context) {
+        runCatching {
+            val json = JSONObject()
+            roomLastSeen.forEach { (room, time) -> json.put(room, time) }
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(KEY_ROOM_TIMES, json.toString())
+                .apply()
+        }.onFailure {
+            Log.e("MotherKakao", "방 캐시 저장 실패", it)
+        }
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/penalty/PenaltyLocalStore.kt
+++ b/app/src/main/java/com/smartpet/todo/penalty/PenaltyLocalStore.kt
@@ -1,0 +1,87 @@
+package com.smartpet.todo.penalty
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import java.io.File
+
+class PenaltyLocalStore(
+    private val rootDir: File,
+    private val gson: Gson = GsonBuilder().setPrettyPrinting().create()
+) {
+    private val settingsFile = File(rootDir, "penalty-settings.json")
+    private val profilesFile = File(rootDir, "penalty-profiles.json")
+    private val triggersFile = File(rootDir, "penalty-triggers.json")
+
+    init {
+        if (!rootDir.exists()) {
+            rootDir.mkdirs()
+        }
+    }
+
+    @Synchronized
+    fun loadSettings(): PenaltySettings {
+        if (!settingsFile.exists()) return PenaltySettings()
+        return runCatching {
+            gson.fromJson(settingsFile.readText(), PenaltySettings::class.java) ?: PenaltySettings()
+        }.getOrDefault(PenaltySettings())
+    }
+
+    @Synchronized
+    fun saveSettings(settings: PenaltySettings) {
+        settingsFile.writeText(gson.toJson(settings))
+    }
+
+    @Synchronized
+    fun loadProfiles(): Map<String, PenaltyProfile> {
+        if (!profilesFile.exists()) return emptyMap()
+        val type = object : TypeToken<List<PenaltyProfile>>() {}.type
+        val list = runCatching {
+            gson.fromJson<List<PenaltyProfile>>(profilesFile.readText(), type) ?: emptyList()
+        }.getOrDefault(emptyList())
+        return list.associateBy { it.taskId }
+    }
+
+    @Synchronized
+    fun saveProfile(profile: PenaltyProfile) {
+        val next = loadProfiles().toMutableMap()
+        next[profile.taskId] = profile.copy(updatedAt = System.currentTimeMillis())
+        profilesFile.writeText(gson.toJson(next.values.sortedBy { it.taskId }))
+    }
+
+    @Synchronized
+    fun saveProfiles(profiles: Collection<PenaltyProfile>) {
+        profilesFile.writeText(gson.toJson(profiles.sortedBy { it.taskId }))
+    }
+
+    @Synchronized
+    fun removeProfile(taskId: String) {
+        val next = loadProfiles().toMutableMap()
+        next.remove(taskId)
+        saveProfiles(next.values)
+    }
+
+    @Synchronized
+    fun loadTriggers(): Map<String, PenaltyTriggerRecord> {
+        if (!triggersFile.exists()) return emptyMap()
+        val type = object : TypeToken<List<PenaltyTriggerRecord>>() {}.type
+        val list = runCatching {
+            gson.fromJson<List<PenaltyTriggerRecord>>(triggersFile.readText(), type) ?: emptyList()
+        }.getOrDefault(emptyList())
+        return list.associateBy { it.taskId }
+    }
+
+    @Synchronized
+    fun markTriggered(record: PenaltyTriggerRecord) {
+        val next = loadTriggers().toMutableMap()
+        next[record.taskId] = record
+        triggersFile.writeText(gson.toJson(next.values.sortedBy { it.taskId }))
+    }
+
+    @Synchronized
+    fun clearTriggered(taskId: String) {
+        val next = loadTriggers().toMutableMap()
+        next.remove(taskId)
+        triggersFile.writeText(gson.toJson(next.values.sortedBy { it.taskId }))
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/penalty/PenaltyManager.kt
+++ b/app/src/main/java/com/smartpet/todo/penalty/PenaltyManager.kt
@@ -1,0 +1,164 @@
+package com.smartpet.todo.penalty
+
+import android.Manifest
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.core.content.ContextCompat
+import com.smartpet.todo.admin.LockTaskController
+import com.smartpet.todo.data.Task
+import com.smartpet.todo.kakao.KakaoMessageSender
+import com.smartpet.todo.kakao.KakaoNotificationAccess
+import com.smartpet.todo.kakao.KakaoSessionManager
+
+class PenaltyManager(private val context: Context) {
+    private val store = PenaltyLocalStore(context.filesDir)
+    private val kakaoMessageSender = KakaoMessageSender(context)
+
+    fun loadSettings(): PenaltySettings = store.loadSettings()
+
+    fun saveSettings(settings: PenaltySettings) {
+        store.saveSettings(settings)
+    }
+
+    fun loadProfiles(): Map<String, PenaltyProfile> = store.loadProfiles()
+
+    fun saveProfile(profile: PenaltyProfile) {
+        store.saveProfile(profile)
+    }
+
+    fun clearTrigger(taskId: String) {
+        store.clearTriggered(taskId)
+    }
+
+    fun runtimeStatus(): PenaltyRuntimeStatus {
+        val lockTaskStatus = LockTaskController.status(context)
+        return PenaltyRuntimeStatus(
+            notificationListenerEnabled = KakaoNotificationAccess.isEnabled(context),
+            cachedKakaoRooms = KakaoSessionManager.getRegisteredRooms(context).map { it.name },
+            activeKakaoSessions = KakaoSessionManager.getRegisteredRooms(context)
+                .filter { it.hasActiveSession }
+                .map { it.name },
+            isDeviceOwnerApp = lockTaskStatus.isDeviceOwnerApp,
+            isLockTaskPermitted = lockTaskStatus.isLockTaskPermitted,
+            canPlaceCalls = ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+
+    fun resolve(task: Task, profile: PenaltyProfile?): PenaltyResolution {
+        return PenaltySelector.resolve(
+            task = task,
+            profile = profile,
+            settings = loadSettings(),
+            runtimeStatus = runtimeStatus()
+        )
+    }
+
+    fun triggerIfNeeded(activity: Activity, task: Task, resolution: PenaltyResolution): PenaltyExecutionResult {
+        val alreadyTriggered = store.loadTriggers()[task.id]
+        if (alreadyTriggered?.penaltyType == resolution.selectedType) {
+            return PenaltyExecutionResult(
+                success = true,
+                userMessage = "같은 벌칙은 이미 한 번 실행했어요.",
+                triggeredType = resolution.selectedType
+            )
+        }
+
+        val result = when (resolution.selectedType) {
+            PenaltyType.PROOF_REQUIRED -> PenaltyExecutionResult(
+                success = true,
+                userMessage = "인증을 완료할 때까지 이 화면을 유지해요.",
+                triggeredType = PenaltyType.PROOF_REQUIRED
+            )
+
+            PenaltyType.DEVICE_LOCK -> {
+                if (LockTaskController.startLockTaskIfPermitted(activity)) {
+                    PenaltyExecutionResult(true, "이 작업은 인증 전까지 앱 잠금이 유지됩니다.", PenaltyType.DEVICE_LOCK)
+                } else {
+                    PenaltyExecutionResult(
+                        success = false,
+                        userMessage = "앱 잠금을 시작하지 못했어요.",
+                        triggeredType = PenaltyType.DEVICE_LOCK,
+                        blockedReason = PenaltySelector.blockedReason(PenaltyType.DEVICE_LOCK, loadSettings(), runtimeStatus())
+                    )
+                }
+            }
+
+            PenaltyType.ACCOUNTABILITY_CALL -> triggerAccountabilityCall(activity)
+            PenaltyType.ACCOUNTABILITY_KAKAO -> triggerAccountabilityKakao(task)
+        }
+
+        if (result.success) {
+            store.markTriggered(PenaltyTriggerRecord(task.id, resolution.selectedType))
+        }
+        return result
+    }
+
+    fun stopLockTaskIfNeeded(activity: Activity, resolution: PenaltyResolution?) {
+        if (resolution?.selectedType == PenaltyType.DEVICE_LOCK) {
+            LockTaskController.stopLockTaskSafely(activity)
+        }
+    }
+
+    private fun triggerAccountabilityCall(activity: Activity): PenaltyExecutionResult {
+        val settings = loadSettings()
+        val phoneNumber = settings.target.phoneNumber.filter { it.isDigit() || it == '+' }
+        if (phoneNumber.isBlank()) {
+            return PenaltyExecutionResult(
+                success = false,
+                userMessage = "전화 벌칙을 실행할 수 없어요.",
+                triggeredType = PenaltyType.ACCOUNTABILITY_CALL,
+                blockedReason = "책임 파트너 전화번호를 먼저 입력하세요."
+            )
+        }
+
+        val callUri = Uri.parse("tel:$phoneNumber")
+        val canCallDirectly = ContextCompat.checkSelfPermission(activity, Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED
+        val callIntent = Intent(if (canCallDirectly) Intent.ACTION_CALL else Intent.ACTION_DIAL).apply {
+            data = callUri
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        return try {
+            activity.startActivity(callIntent)
+            val userMessage = if (canCallDirectly) {
+                "책임 파트너에게 바로 전화 연결을 시작했어요."
+            } else {
+                "통화 권한이 없어 다이얼 화면으로 보냈어요. 직접 통화를 시작하세요."
+            }
+            PenaltyExecutionResult(true, userMessage, PenaltyType.ACCOUNTABILITY_CALL)
+        } catch (_: ActivityNotFoundException) {
+            PenaltyExecutionResult(
+                success = false,
+                userMessage = "전화 앱을 찾지 못했어요.",
+                triggeredType = PenaltyType.ACCOUNTABILITY_CALL,
+                blockedReason = "통화 앱이 없어 전화 벌칙을 실행할 수 없어요."
+            )
+        }
+    }
+
+    private fun triggerAccountabilityKakao(task: Task): PenaltyExecutionResult {
+        val settings = loadSettings()
+        val roomName = settings.target.kakaoRoomName.trim()
+        if (roomName.isBlank()) {
+            return PenaltyExecutionResult(
+                success = false,
+                userMessage = "카카오 벌칙을 실행할 수 없어요.",
+                triggeredType = PenaltyType.ACCOUNTABILITY_KAKAO,
+                blockedReason = "책임 파트너 카카오톡 방 이름을 먼저 입력하세요."
+            )
+        }
+
+        val message = PenaltyMessageFormatter.formatKakaoMessage(settings, task)
+        val sendResult = kakaoMessageSender.send(roomName, message)
+        return PenaltyExecutionResult(
+            success = sendResult.success,
+            userMessage = sendResult.message,
+            triggeredType = PenaltyType.ACCOUNTABILITY_KAKAO,
+            blockedReason = sendResult.message.takeIf { !sendResult.success }
+        )
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/penalty/PenaltyMessageFormatter.kt
+++ b/app/src/main/java/com/smartpet/todo/penalty/PenaltyMessageFormatter.kt
@@ -1,0 +1,14 @@
+package com.smartpet.todo.penalty
+
+import com.smartpet.todo.data.Task
+
+object PenaltyMessageFormatter {
+    fun formatKakaoMessage(settings: PenaltySettings, task: Task): String {
+        val partnerName = settings.target.partnerName.ifBlank { "책임 파트너" }
+        return settings.kakaoMessageTemplate
+            .replace("{partnerName}", partnerName)
+            .replace("{taskTitle}", task.title.trim())
+            .replace("{taskDescription}", task.description.trim())
+            .trim()
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/penalty/PenaltyModels.kt
+++ b/app/src/main/java/com/smartpet/todo/penalty/PenaltyModels.kt
@@ -1,0 +1,115 @@
+package com.smartpet.todo.penalty
+
+import com.smartpet.todo.data.Task
+
+enum class PenaltyType {
+    PROOF_REQUIRED,
+    DEVICE_LOCK,
+    ACCOUNTABILITY_CALL,
+    ACCOUNTABILITY_KAKAO
+}
+
+enum class PenaltySelectionMode {
+    AUTO,
+    MANUAL
+}
+
+enum class TaskCategory {
+    DEVICE_REQUIRED,
+    PHOTO_VERIFIABLE,
+    OFFLINE_PHYSICAL,
+    GENERIC
+}
+
+data class PenaltyTarget(
+    val partnerName: String = "",
+    val phoneNumber: String = "",
+    val kakaoRoomName: String = ""
+)
+
+data class PenaltySettings(
+    val target: PenaltyTarget = PenaltyTarget(),
+    val kakaoMessageTemplate: String = DEFAULT_KAKAO_TEMPLATE,
+    val callDialFallbackEnabled: Boolean = true
+) {
+    companion object {
+        const val DEFAULT_KAKAO_TEMPLATE = "[마더] {partnerName}님, \"{taskTitle}\" 작업이 아직 완료되지 않았어요. 지금 확인 부탁드려요."
+    }
+}
+
+data class PenaltyProfile(
+    val taskId: String,
+    val selectionMode: PenaltySelectionMode = PenaltySelectionMode.AUTO,
+    val manualPenaltyType: PenaltyType? = null,
+    val updatedAt: Long = System.currentTimeMillis()
+)
+
+data class PenaltyRecommendation(
+    val category: TaskCategory,
+    val type: PenaltyType,
+    val reason: String,
+    val blockedReason: String? = null
+) {
+    val isReady: Boolean
+        get() = blockedReason == null
+}
+
+data class PenaltyResolution(
+    val profile: PenaltyProfile,
+    val recommendation: PenaltyRecommendation,
+    val selectedType: PenaltyType,
+    val usingManualOverride: Boolean,
+    val blockedReason: String? = recommendation.blockedReason
+)
+
+data class PenaltyDraft(
+    val selectionMode: PenaltySelectionMode,
+    val manualPenaltyType: PenaltyType?
+)
+
+data class PenaltyRuntimeStatus(
+    val notificationListenerEnabled: Boolean = false,
+    val cachedKakaoRooms: List<String> = emptyList(),
+    val activeKakaoSessions: List<String> = emptyList(),
+    val isDeviceOwnerApp: Boolean = false,
+    val isLockTaskPermitted: Boolean = false,
+    val canPlaceCalls: Boolean = false
+)
+
+data class PenaltyTriggerRecord(
+    val taskId: String,
+    val penaltyType: PenaltyType,
+    val triggeredAt: Long = System.currentTimeMillis()
+)
+
+data class PenaltyExecutionResult(
+    val success: Boolean,
+    val userMessage: String,
+    val triggeredType: PenaltyType,
+    val blockedReason: String? = null
+)
+
+data class TaskPenaltyPresentation(
+    val label: String,
+    val detail: String,
+    val warning: String? = null
+)
+
+fun PenaltyResolution.toPresentation(): TaskPenaltyPresentation {
+    val label = when (selectedType) {
+        PenaltyType.PROOF_REQUIRED -> "벌칙: 인증 고정"
+        PenaltyType.DEVICE_LOCK -> "벌칙: 앱 고정 잠금"
+        PenaltyType.ACCOUNTABILITY_CALL -> "벌칙: 책임 파트너 전화"
+        PenaltyType.ACCOUNTABILITY_KAKAO -> "벌칙: 책임 파트너 카카오톡"
+    }
+    val detail = if (usingManualOverride) {
+        "수동 지정 · ${recommendation.reason}"
+    } else {
+        "자동 선택 · ${recommendation.reason}"
+    }
+    return TaskPenaltyPresentation(label = label, detail = detail, warning = blockedReason)
+}
+
+fun Task.asPenaltyProfile(existing: PenaltyProfile?): PenaltyProfile {
+    return existing ?: PenaltyProfile(taskId = id)
+}

--- a/app/src/main/java/com/smartpet/todo/penalty/PenaltySelector.kt
+++ b/app/src/main/java/com/smartpet/todo/penalty/PenaltySelector.kt
@@ -1,0 +1,152 @@
+package com.smartpet.todo.penalty
+
+import com.smartpet.todo.data.Task
+import java.util.Locale
+
+object PenaltySelector {
+    private val deviceRequiredKeywords = listOf(
+        "코딩", "개발", "프로그래밍", "디버깅", "리팩토링", "문서", "조사", "공부", "강의", "writing",
+        "coding", "development", "debug", "study", "research", "docs", "documentation"
+    )
+    private val photoVerifiableKeywords = listOf(
+        "운동", "러닝", "산책", "설거지", "청소", "빨래", "정리", "요리", "식사", "물", "약", "스트레칭",
+        "workout", "run", "walk", "clean", "laundry", "cook", "meal", "dish", "medicine"
+    )
+    private val offlinePhysicalKeywords = listOf(
+        "숙제", "발표", "연습", "미팅", "회의", "준비", "외출", "장보기", "업무", "exercise",
+        "meeting", "practice", "prep", "shopping", "errand"
+    )
+
+    fun classify(task: Task): TaskCategory {
+        val haystack = listOf(task.title, task.description)
+            .joinToString(" ")
+            .lowercase(Locale.KOREA)
+
+        return when {
+            haystack.containsAny(deviceRequiredKeywords) -> TaskCategory.DEVICE_REQUIRED
+            haystack.containsAny(photoVerifiableKeywords) -> TaskCategory.PHOTO_VERIFIABLE
+            haystack.containsAny(offlinePhysicalKeywords) -> TaskCategory.OFFLINE_PHYSICAL
+            else -> TaskCategory.GENERIC
+        }
+    }
+
+    fun recommend(
+        task: Task,
+        settings: PenaltySettings,
+        runtimeStatus: PenaltyRuntimeStatus
+    ): PenaltyRecommendation {
+        val category = classify(task)
+        return when (category) {
+            TaskCategory.DEVICE_REQUIRED -> PenaltyRecommendation(
+                category = category,
+                type = PenaltyType.PROOF_REQUIRED,
+                reason = "디바이스가 필요한 목표라 잠금형 벌칙을 제외하고 인증형으로 고정했어요."
+            )
+
+            TaskCategory.PHOTO_VERIFIABLE -> PenaltyRecommendation(
+                category = category,
+                type = PenaltyType.PROOF_REQUIRED,
+                reason = "사진으로 끝났는지 검증하기 쉬운 작업이라 인증형 벌칙이 가장 직접적이에요."
+            )
+
+            TaskCategory.OFFLINE_PHYSICAL -> pickExternalOrLock(
+                category = category,
+                settings = settings,
+                runtimeStatus = runtimeStatus,
+                fallbackReason = "오프라인 행동 작업이라 외부 개입 또는 잠금형 벌칙이 효과적이에요."
+            )
+
+            TaskCategory.GENERIC -> pickExternalOrLock(
+                category = category,
+                settings = settings,
+                runtimeStatus = runtimeStatus,
+                fallbackReason = "일반 작업은 책임 파트너 개입이 가능하면 먼저 쓰고, 아니면 인증형으로 내려가요."
+            )
+        }
+    }
+
+    fun resolve(
+        task: Task,
+        profile: PenaltyProfile?,
+        settings: PenaltySettings,
+        runtimeStatus: PenaltyRuntimeStatus
+    ): PenaltyResolution {
+        val safeProfile = profile ?: PenaltyProfile(taskId = task.id)
+        val recommendation = recommend(task, settings, runtimeStatus)
+        val selectedType = if (safeProfile.selectionMode == PenaltySelectionMode.MANUAL) {
+            safeProfile.manualPenaltyType ?: recommendation.type
+        } else {
+            recommendation.type
+        }
+        val blockedReason = blockedReason(selectedType, settings, runtimeStatus)
+        val effectiveRecommendation = if (blockedReason == null || selectedType == recommendation.type) {
+            recommendation.copy(blockedReason = blockedReason)
+        } else {
+            recommendation.copy(
+                blockedReason = blockedReason,
+                reason = recommendation.reason
+            )
+        }
+        return PenaltyResolution(
+            profile = safeProfile,
+            recommendation = effectiveRecommendation,
+            selectedType = selectedType,
+            usingManualOverride = safeProfile.selectionMode == PenaltySelectionMode.MANUAL && safeProfile.manualPenaltyType != null,
+            blockedReason = blockedReason
+        )
+    }
+
+    fun blockedReason(
+        type: PenaltyType,
+        settings: PenaltySettings,
+        runtimeStatus: PenaltyRuntimeStatus
+    ): String? {
+        return when (type) {
+            PenaltyType.PROOF_REQUIRED -> null
+            PenaltyType.DEVICE_LOCK -> if (runtimeStatus.isLockTaskPermitted) null else "기기 소유자 잠금 설정이 아직 완료되지 않았어요."
+            PenaltyType.ACCOUNTABILITY_CALL -> if (settings.target.phoneNumber.isBlank()) "책임 파트너 전화번호를 먼저 입력하세요." else null
+            PenaltyType.ACCOUNTABILITY_KAKAO -> when {
+                settings.target.kakaoRoomName.isBlank() -> "책임 파트너 카카오톡 방 이름을 먼저 입력하세요."
+                !runtimeStatus.notificationListenerEnabled -> "카카오 세션 캐시를 위해 알림 접근 권한이 필요해요."
+                else -> null
+            }
+        }
+    }
+
+    private fun pickExternalOrLock(
+        category: TaskCategory,
+        settings: PenaltySettings,
+        runtimeStatus: PenaltyRuntimeStatus,
+        fallbackReason: String
+    ): PenaltyRecommendation {
+        return when {
+            runtimeStatus.isLockTaskPermitted -> PenaltyRecommendation(
+                category = category,
+                type = PenaltyType.DEVICE_LOCK,
+                reason = "$fallbackReason 기기 고정 잠금이 준비돼 있어 우선 적용했어요."
+            )
+
+            settings.target.kakaoRoomName.isNotBlank() -> PenaltyRecommendation(
+                category = category,
+                type = PenaltyType.ACCOUNTABILITY_KAKAO,
+                reason = "$fallbackReason 책임 파트너 카카오톡으로 바로 개입을 요청해요.",
+                blockedReason = blockedReason(PenaltyType.ACCOUNTABILITY_KAKAO, settings, runtimeStatus)
+            )
+
+            settings.target.phoneNumber.isNotBlank() -> PenaltyRecommendation(
+                category = category,
+                type = PenaltyType.ACCOUNTABILITY_CALL,
+                reason = "$fallbackReason 책임 파트너에게 즉시 전화를 연결해요.",
+                blockedReason = blockedReason(PenaltyType.ACCOUNTABILITY_CALL, settings, runtimeStatus)
+            )
+
+            else -> PenaltyRecommendation(
+                category = category,
+                type = PenaltyType.PROOF_REQUIRED,
+                reason = "$fallbackReason 외부 개입 대상이 아직 설정되지 않아 인증형으로 내려갔어요."
+            )
+        }
+    }
+
+    private fun String.containsAny(keywords: List<String>): Boolean = keywords.any { contains(it) }
+}

--- a/app/src/main/java/com/smartpet/todo/ui/OverdueVerificationActivity.kt
+++ b/app/src/main/java/com/smartpet/todo/ui/OverdueVerificationActivity.kt
@@ -16,10 +16,11 @@ import android.os.Bundle
 import android.provider.OpenableColumns
 import android.widget.Toast
 import androidx.activity.ComponentActivity
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.OnBackPressedCallback
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -28,8 +29,8 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -39,11 +40,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -57,6 +60,10 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.smartpet.todo.R
 import com.smartpet.todo.data.RemoteStorage
+import com.smartpet.todo.data.Task
+import com.smartpet.todo.penalty.PenaltyManager
+import com.smartpet.todo.penalty.PenaltyResolution
+import com.smartpet.todo.penalty.toPresentation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -72,6 +79,10 @@ class OverdueVerificationActivity : ComponentActivity() {
     private var taskId: String = ""
     private var taskTitle: String = ""
     private var taskDescription: String = ""
+    private var resolution: PenaltyResolution? = null
+    private var isResolved = false
+    private val penaltyManager by lazy { PenaltyManager(applicationContext) }
+
     private val notificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
             if (granted) {
@@ -84,18 +95,29 @@ class OverdueVerificationActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setShowWhenLocked(true)
-        setTurnScreenOn(true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        } else {
+            @Suppress("DEPRECATION")
+            window.addFlags(android.view.WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or android.view.WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON)
+        }
 
         taskId = intent.getStringExtra("taskId").orEmpty()
         taskTitle = intent.getStringExtra("taskTitle").orEmpty()
         taskDescription = intent.getStringExtra("taskDescription").orEmpty()
-        val storage = RemoteStorage()
-
         ensureNotificationChannel()
+        installBackBlocker()
+
+        val task = Task(id = taskId, title = taskTitle.ifBlank { "할 일" }, description = taskDescription)
+        resolution = penaltyManager.resolve(task, penaltyManager.loadProfiles()[taskId])
 
         setContent {
+            val currentResolution = resolution
             var loading by remember { mutableStateOf(false) }
+            var bannerMessage by remember(currentResolution) {
+                mutableStateOf(currentResolution?.toPresentation()?.detail ?: "인증을 완료할 때까지 이 화면을 유지합니다.")
+            }
             val infiniteTransition = rememberInfiniteTransition(label = "overdue-alert")
             val warningOverlayAlpha by infiniteTransition.animateFloat(
                 initialValue = 0.2f,
@@ -120,6 +142,7 @@ class OverdueVerificationActivity : ComponentActivity() {
                 if (uri == null) return@rememberLauncherForActivityResult
                 loading = true
                 lifecycleScope.launch {
+                    val storage = RemoteStorage()
                     val uploadImage = withContext(Dispatchers.IO) { readUploadImage(uri) }
                     if (uploadImage == null) {
                         loading = false
@@ -129,20 +152,25 @@ class OverdueVerificationActivity : ComponentActivity() {
 
                     val taskPayload = buildTaskPayload(taskTitle, taskDescription)
                     runCatching { storage.verifyPhoto(taskId, taskPayload, uploadImage) }
-                        .onSuccess {
+                        .onSuccess { verifyResult ->
                             loading = false
-                            Toast.makeText(this@OverdueVerificationActivity, it.message, Toast.LENGTH_SHORT).show()
-                            if (it.verified) {
+                            bannerMessage = verifyResult.message
+                            Toast.makeText(this@OverdueVerificationActivity, verifyResult.message, Toast.LENGTH_SHORT).show()
+                            if (verifyResult.verified) {
+                                runCatching { storage.toggleTaskCompletion(taskId) }
+                                isResolved = true
+                                penaltyManager.clearTrigger(taskId)
+                                penaltyManager.stopLockTaskIfNeeded(this@OverdueVerificationActivity, currentResolution)
                                 stopSiren()
                                 stopWarningNotifications(cancelNotice = true)
-                                runCatching { storage.toggleTaskCompletion(taskId) }
                                 finish()
                             }
                         }
                         .onFailure {
                             loading = false
-                            Toast.makeText(this@OverdueVerificationActivity, "인증 실패: ${it.message}", Toast.LENGTH_SHORT).show()
-                    }
+                            bannerMessage = "인증 실패: ${it.message ?: "알 수 없는 오류"}"
+                            Toast.makeText(this@OverdueVerificationActivity, bannerMessage, Toast.LENGTH_SHORT).show()
+                        }
                 }
             }
 
@@ -151,10 +179,7 @@ class OverdueVerificationActivity : ComponentActivity() {
                     .fillMaxSize()
                     .background(
                         Brush.verticalGradient(
-                            listOf(
-                                Color(0xFF140607),
-                                Color(0xFF050505)
-                            )
+                            listOf(Color(0xFF140607), Color(0xFF050505))
                         )
                     )
             ) {
@@ -179,7 +204,7 @@ class OverdueVerificationActivity : ComponentActivity() {
                         modifier = Modifier.offset(x = warningOffsetX.dp)
                     )
                     Text(
-                        text = "로봇이 쫓아오고 있어요",
+                        text = currentResolution?.toPresentation()?.label ?: "인증 고정",
                         color = Color.White,
                         style = MaterialTheme.typography.titleLarge,
                         fontWeight = FontWeight.ExtraBold,
@@ -218,14 +243,23 @@ class OverdueVerificationActivity : ComponentActivity() {
                                     style = MaterialTheme.typography.bodyMedium
                                 )
                             }
+                            Text(
+                                text = bannerMessage,
+                                color = Color.White,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            currentResolution?.blockedReason?.let {
+                                Text(
+                                    text = "주의: $it",
+                                    color = Color(0xFFFFB4B4),
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
                         }
                     }
 
                     if (loading) {
-                        CircularProgressIndicator(
-                            color = Color(0xFFFF6B6B),
-                            modifier = Modifier.padding(top = 24.dp)
-                        )
+                        CircularProgressIndicator(color = Color(0xFFFF6B6B), modifier = Modifier.padding(top = 24.dp))
                         Text(
                             text = "사진 분석 중... 잠시만 기다려주세요",
                             color = Color.White,
@@ -257,16 +291,13 @@ class OverdueVerificationActivity : ComponentActivity() {
                         }
                     }
 
-                    OutlinedButton(
-                        onClick = { finish() },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 12.dp),
-                        border = BorderStroke(1.dp, Color(0xFFFF8A8A)),
-                        colors = ButtonDefaults.outlinedButtonColors(contentColor = Color(0xFFFFD5D5))
-                    ) {
-                        Text("잠시 후 다시 시도")
-                    }
+                    Text(
+                        text = "뒤로가기와 임시 닫기는 막혀 있어요. 인증 성공 전에는 완료로 처리되지 않습니다.",
+                        color = Color(0xFFFFD5D5),
+                        style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(top = 18.dp)
+                    )
                 }
             }
         }
@@ -277,17 +308,30 @@ class OverdueVerificationActivity : ComponentActivity() {
         ensureNotificationPermission()
         startSiren()
         startWarningNotifications()
+        triggerPenaltyOnce()
     }
 
     override fun onStop() {
-        stopWarningNotifications(cancelNotice = true)
+        stopWarningNotifications(cancelNotice = isResolved)
         stopSiren()
         super.onStop()
     }
 
+    private fun triggerPenaltyOnce() {
+        val task = Task(id = taskId, title = taskTitle.ifBlank { "할 일" }, description = taskDescription)
+        val resolved = resolution ?: return
+        val result = penaltyManager.triggerIfNeeded(this, task, resolved)
+        Toast.makeText(this, result.userMessage, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun installBackBlocker() {
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() = Unit
+        })
+    }
+
     private fun startSiren() {
         if (sirenJob != null) return
-
         toneGenerator = ToneGenerator(AudioManager.STREAM_ALARM, 100)
         sirenJob = lifecycleScope.launch {
             while (isActive) {
@@ -336,10 +380,10 @@ class OverdueVerificationActivity : ComponentActivity() {
             setSound(alarmSound, attrs)
         }
 
-        val manager = getSystemService(NotificationManager::class.java)
-        manager.createNotificationChannel(channel)
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
     }
 
+    @android.annotation.SuppressLint("MissingPermission")
     private fun startWarningNotifications() {
         if (warningNotificationJob != null) return
         if (!canPostNotifications()) return
@@ -361,10 +405,7 @@ class OverdueVerificationActivity : ComponentActivity() {
             while (isActive) {
                 if (canPostNotifications()) {
                     val message = warnings[index % warnings.size]
-                    manager.notify(
-                        CHASE_NOTIFICATION_ID,
-                        buildWarningNotification(message)
-                    )
+                    runCatching { manager.notify(CHASE_NOTIFICATION_ID, buildWarningNotification(message)) }
                     index++
                 }
                 delay(1_000L)
@@ -397,12 +438,7 @@ class OverdueVerificationActivity : ComponentActivity() {
         }
 
         val pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            taskId.hashCode(),
-            openIntent,
-            pendingIntentFlags
-        )
+        val pendingIntent = PendingIntent.getActivity(this, taskId.hashCode(), openIntent, pendingIntentFlags)
 
         return NotificationCompat.Builder(this, CHASE_CHANNEL_ID)
             .setSmallIcon(R.mipmap.ic_launcher)
@@ -438,11 +474,7 @@ private fun OverdueVerificationActivity.readUploadImage(uri: Uri): RemoteStorage
         ?: URLConnection.guessContentTypeFromName(name)
         ?: "application/octet-stream"
 
-    return RemoteStorage.UploadImage(
-        filename = name,
-        mimeType = mimeType,
-        bytes = bytes
-    )
+    return RemoteStorage.UploadImage(filename = name, mimeType = mimeType, bytes = bytes)
 }
 
 private fun OverdueVerificationActivity.queryDisplayName(uri: Uri): String? {

--- a/app/src/main/java/com/smartpet/todo/ui/TaskListScreen.kt
+++ b/app/src/main/java/com/smartpet/todo/ui/TaskListScreen.kt
@@ -6,6 +6,7 @@ import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -14,42 +15,72 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
 import com.smartpet.todo.data.RemoteStorage
 import com.smartpet.todo.data.Task
 import com.smartpet.todo.data.TaskPriority
+import com.smartpet.todo.penalty.PenaltyDraft
+import com.smartpet.todo.penalty.PenaltyProfile
+import com.smartpet.todo.penalty.PenaltySelector
+import com.smartpet.todo.penalty.PenaltySettings
+import com.smartpet.todo.penalty.toPresentation
 import com.smartpet.todo.pet.PetBehavior
+import com.smartpet.todo.ui.components.PenaltySettingsDialog
 import com.smartpet.todo.ui.components.PetStatusCard
 import com.smartpet.todo.ui.components.TaskCard
 import com.smartpet.todo.ui.components.TaskEditorDialog
@@ -60,15 +91,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.net.URLConnection
 
-/**
- * Main task list screen with pet status and task items
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TaskListScreen(
     uiState: TaskUiState,
-    onAddTask: (String, String, Long?, TaskPriority, Int, Int?) -> Unit,
-    onUpdateTask: (Task) -> Unit,
+    onAddTask: (String, String, Long?, TaskPriority, Int, Int?, PenaltyDraft) -> Unit,
+    onUpdateTask: (Task, PenaltyDraft) -> Unit,
+    onSavePenaltySettings: (PenaltySettings) -> Unit,
     onToggleComplete: (String) -> Unit,
     onDeleteTask: (String) -> Unit,
     onRestoreTask: (Task) -> Unit,
@@ -81,6 +110,7 @@ fun TaskListScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     var pendingVerifyTask by remember { mutableStateOf<Task?>(null) }
     var verifyingTaskId by remember { mutableStateOf<String?>(null) }
+    var isSettingsOpen by rememberSaveable { mutableStateOf(false) }
 
     val verifyPickerLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
         val task = pendingVerifyTask
@@ -116,7 +146,6 @@ fun TaskListScreen(
         }
     }
 
-    // Recompose periodically so due/urgency updates without user interaction.
     val nowMillis by produceState(initialValue = System.currentTimeMillis()) {
         while (true) {
             delay(30_000L)
@@ -158,11 +187,7 @@ fun TaskListScreen(
             LargeTopAppBar(
                 title = {
                     Column {
-                        Text(
-                            text = "마더",
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
+                        Text(text = "마더", maxLines = 1, overflow = TextOverflow.Ellipsis)
                         Text(
                             text = "미루지 않게, 환경이 도와줘요",
                             style = MaterialTheme.typography.bodySmall,
@@ -174,10 +199,16 @@ fun TaskListScreen(
                 },
                 actions = {
                     IconButton(
+                        onClick = { isSettingsOpen = true },
+                        modifier = Modifier.testTag("settings_button")
+                    ) {
+                        Icon(Icons.Rounded.Settings, contentDescription = "벌칙 설정")
+                    }
+                    IconButton(
                         onClick = onRefresh,
                         modifier = Modifier.testTag("refresh_button")
                     ) {
-                        Icon(imageVector = Icons.Rounded.Refresh, contentDescription = "새로고침")
+                        Icon(Icons.Rounded.Refresh, contentDescription = "새로고침")
                     }
                 }
             )
@@ -197,11 +228,7 @@ fun TaskListScreen(
                     ),
                 shape = CircleShape
             ) {
-                Icon(
-                    imageVector = Icons.Rounded.Add,
-                    contentDescription = "할 일 추가",
-                    modifier = Modifier.size(28.dp)
-                )
+                Icon(Icons.Rounded.Add, contentDescription = "할 일 추가", modifier = Modifier.size(28.dp))
             }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
@@ -239,26 +266,18 @@ fun TaskListScreen(
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         PetStatusCard(petState = petState)
-                        StatsCard(
-                            totalCount = totalCount,
-                            completedCount = completedCount,
-                            overdueCount = overdueCount
-                        )
-                        TaskFilterRow(
-                            filter = filter,
-                            onFilterChange = { filter = it }
-                        )
+                        StatsCard(totalCount, completedCount, overdueCount)
+                        PenaltyOverviewCard(uiState = uiState)
+                        TaskFilterRow(filter = filter, onFilterChange = { filter = it })
                     }
 
-                    Box(
-                        modifier = Modifier.weight(1f),
-                        contentAlignment = Alignment.TopCenter
-                    ) {
+                    Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.TopCenter) {
                         TasksList(
                             filter = filter,
                             activeTasks = activeTasks,
                             completedTasks = completedTasks,
                             nowMillis = nowMillis,
+                            uiState = uiState,
                             listState = listState,
                             onTaskClick = { task ->
                                 editorTask = task
@@ -291,21 +310,15 @@ fun TaskListScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     PetStatusCard(petState = petState)
-                    StatsCard(
-                        totalCount = totalCount,
-                        completedCount = completedCount,
-                        overdueCount = overdueCount
-                    )
-                    TaskFilterRow(
-                        filter = filter,
-                        onFilterChange = { filter = it }
-                    )
-
+                    StatsCard(totalCount, completedCount, overdueCount)
+                    PenaltyOverviewCard(uiState = uiState)
+                    TaskFilterRow(filter = filter, onFilterChange = { filter = it })
                     TasksList(
                         filter = filter,
                         activeTasks = activeTasks,
                         completedTasks = completedTasks,
                         nowMillis = nowMillis,
+                        uiState = uiState,
                         listState = listState,
                         onTaskClick = { task ->
                             editorTask = task
@@ -334,14 +347,17 @@ fun TaskListScreen(
     if (isEditorOpen) {
         TaskEditorDialog(
             initialTask = editorTask,
+            initialPenaltyProfile = editorTask?.let { uiState.penaltyProfiles[it.id] },
+            penaltySettings = uiState.penaltySettings,
+            penaltyRuntimeStatus = uiState.penaltyRuntimeStatus,
             onDismiss = {
                 isEditorOpen = false
                 editorTask = null
             },
-            onSave = { title, description, dueDate, priority, maxEnforcementLevel, estimatedMinutes ->
+            onSave = { title, description, dueDate, priority, maxEnforcementLevel, estimatedMinutes, penaltyDraft ->
                 val editing = editorTask
                 if (editing == null) {
-                    onAddTask(title, description, dueDate, priority, maxEnforcementLevel, estimatedMinutes)
+                    onAddTask(title, description, dueDate, priority, maxEnforcementLevel, estimatedMinutes, penaltyDraft)
                 } else {
                     onUpdateTask(
                         editing.copy(
@@ -351,11 +367,24 @@ fun TaskListScreen(
                             priority = priority,
                             maxEnforcementLevel = maxEnforcementLevel,
                             estimatedMinutes = estimatedMinutes
-                        )
+                        ),
+                        penaltyDraft
                     )
                 }
                 isEditorOpen = false
                 editorTask = null
+            }
+        )
+    }
+
+    if (isSettingsOpen) {
+        PenaltySettingsDialog(
+            initialSettings = uiState.penaltySettings,
+            runtimeStatus = uiState.penaltyRuntimeStatus,
+            onDismiss = { isSettingsOpen = false },
+            onSave = {
+                onSavePenaltySettings(it)
+                isSettingsOpen = false
             }
         )
     }
@@ -367,22 +396,20 @@ fun TaskListScreen(
             title = { Text("삭제할까요?") },
             text = { Text("“${task.title}”을(를) 삭제합니다.") },
             confirmButton = {
-                TextButton(
-                    onClick = {
-                        pendingDelete = null
-                        onDeleteTask(task.id)
-                        scope.launch {
-                            val result = snackbarHostState.showSnackbar(
-                                message = "삭제했어요",
-                                actionLabel = "되돌리기",
-                                duration = SnackbarDuration.Short
-                            )
-                            if (result == SnackbarResult.ActionPerformed) {
-                                onRestoreTask(task)
-                            }
+                TextButton(onClick = {
+                    pendingDelete = null
+                    onDeleteTask(task.id)
+                    scope.launch {
+                        val result = snackbarHostState.showSnackbar(
+                            message = "삭제했어요",
+                            actionLabel = "되돌리기",
+                            duration = SnackbarDuration.Short
+                        )
+                        if (result == SnackbarResult.ActionPerformed) {
+                            onRestoreTask(task)
                         }
                     }
-                ) {
+                }) {
                     Text("삭제")
                 }
             },
@@ -418,11 +445,7 @@ private fun StatsCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = "진행 상황",
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold
-                )
+                Text("진행 상황", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
                 if (totalCount > 0) {
                     Text(
                         text = "$completedCount / $totalCount",
@@ -456,7 +479,41 @@ private fun StatsCard(
 }
 
 @Composable
+private fun PenaltyOverviewCard(uiState: TaskUiState) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text("벌칙 준비 상태", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Text(
+                text = buildString {
+                    append(if (uiState.penaltySettings.target.partnerName.isBlank()) "책임 파트너 미설정" else "파트너 ${uiState.penaltySettings.target.partnerName}")
+                    append(" · ")
+                    append(if (uiState.penaltyRuntimeStatus.notificationListenerEnabled) "Kakao 알림 접근 허용" else "Kakao 알림 접근 필요")
+                    append(" · ")
+                    append(if (uiState.penaltyRuntimeStatus.isLockTaskPermitted) "앱 잠금 준비 완료" else "앱 잠금 미준비")
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                lineHeight = 20.sp
+            )
+            if (uiState.penaltyRuntimeStatus.cachedKakaoRooms.isNotEmpty()) {
+                Text(
+                    text = "캐시된 방 ${uiState.penaltyRuntimeStatus.cachedKakaoRooms.size}개",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
+@Composable
 private fun TaskFilterRow(
     filter: TaskFilter,
     onFilterChange: (TaskFilter) -> Unit,
@@ -469,21 +526,9 @@ private fun TaskFilterRow(
             .horizontalScroll(scrollState),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        FilterChip(
-            selected = filter == TaskFilter.ACTIVE,
-            onClick = { onFilterChange(TaskFilter.ACTIVE) },
-            label = { Text("진행중") }
-        )
-        FilterChip(
-            selected = filter == TaskFilter.ALL,
-            onClick = { onFilterChange(TaskFilter.ALL) },
-            label = { Text("전체") }
-        )
-        FilterChip(
-            selected = filter == TaskFilter.COMPLETED,
-            onClick = { onFilterChange(TaskFilter.COMPLETED) },
-            label = { Text("완료") }
-        )
+        FilterChip(selected = filter == TaskFilter.ACTIVE, onClick = { onFilterChange(TaskFilter.ACTIVE) }, label = { Text("진행중") })
+        FilterChip(selected = filter == TaskFilter.ALL, onClick = { onFilterChange(TaskFilter.ALL) }, label = { Text("전체") })
+        FilterChip(selected = filter == TaskFilter.COMPLETED, onClick = { onFilterChange(TaskFilter.COMPLETED) }, label = { Text("완료") })
     }
 }
 
@@ -493,6 +538,7 @@ private fun TasksList(
     activeTasks: List<Task>,
     completedTasks: List<Task>,
     nowMillis: Long,
+    uiState: TaskUiState,
     listState: androidx.compose.foundation.lazy.LazyListState,
     onTaskClick: (Task) -> Unit,
     onToggleComplete: (String) -> Unit,
@@ -518,9 +564,7 @@ private fun TasksList(
         if (showEmpty) {
             item(key = "empty_state") {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 56.dp),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 56.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -544,17 +588,22 @@ private fun TasksList(
 
         if (filter == TaskFilter.ALL || filter == TaskFilter.ACTIVE) {
             item(key = "active_header") {
-                Text(
-                    text = "할 일",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
+                Text("할 일", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
             }
 
             items(activeTasks, key = { it.id }) { task ->
+                val resolution = remember(task, uiState.penaltyProfiles, uiState.penaltySettings, uiState.penaltyRuntimeStatus) {
+                    PenaltySelector.resolve(
+                        task = task,
+                        profile = uiState.penaltyProfiles[task.id],
+                        settings = uiState.penaltySettings,
+                        runtimeStatus = uiState.penaltyRuntimeStatus
+                    )
+                }
                 TaskCard(
                     task = task,
                     nowMillis = nowMillis,
+                    penaltyPresentation = resolution.toPresentation(),
                     onToggleComplete = { onToggleComplete(task.id) },
                     onVerify = { onVerifyTask(task) },
                     isVerifying = verifyingTaskId == task.id,
@@ -576,9 +625,18 @@ private fun TasksList(
             }
 
             items(completedTasks, key = { it.id }) { task ->
+                val resolution = remember(task, uiState.penaltyProfiles, uiState.penaltySettings, uiState.penaltyRuntimeStatus) {
+                    PenaltySelector.resolve(
+                        task = task,
+                        profile = uiState.penaltyProfiles[task.id],
+                        settings = uiState.penaltySettings,
+                        runtimeStatus = uiState.penaltyRuntimeStatus
+                    )
+                }
                 TaskCard(
                     task = task,
                     nowMillis = nowMillis,
+                    penaltyPresentation = resolution.toPresentation(),
                     onToggleComplete = { onToggleComplete(task.id) },
                     onVerify = null,
                     isVerifying = false,
@@ -603,11 +661,7 @@ private fun readUploadImage(contentResolver: ContentResolver, uri: Uri): RemoteS
         ?: URLConnection.guessContentTypeFromName(name)
         ?: "application/octet-stream"
 
-    return RemoteStorage.UploadImage(
-        filename = name,
-        mimeType = mimeType,
-        bytes = bytes
-    )
+    return RemoteStorage.UploadImage(filename = name, mimeType = mimeType, bytes = bytes)
 }
 
 private fun queryDisplayName(contentResolver: ContentResolver, uri: Uri): String? {

--- a/app/src/main/java/com/smartpet/todo/ui/components/PenaltySettingsDialog.kt
+++ b/app/src/main/java/com/smartpet/todo/ui/components/PenaltySettingsDialog.kt
@@ -1,0 +1,203 @@
+package com.smartpet.todo.ui.components
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.smartpet.todo.admin.LockTaskController
+import com.smartpet.todo.kakao.KakaoNotificationAccess
+import com.smartpet.todo.penalty.PenaltyRuntimeStatus
+import com.smartpet.todo.penalty.PenaltySettings
+import com.smartpet.todo.penalty.PenaltyTarget
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PenaltySettingsDialog(
+    initialSettings: PenaltySettings,
+    runtimeStatus: PenaltyRuntimeStatus,
+    onDismiss: () -> Unit,
+    onSave: (PenaltySettings) -> Unit
+) {
+    val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
+    val lockTaskStatus = remember(runtimeStatus.isDeviceOwnerApp, runtimeStatus.isLockTaskPermitted) {
+        LockTaskController.status(context)
+    }
+
+    var partnerName by remember { mutableStateOf(initialSettings.target.partnerName) }
+    var phoneNumber by remember { mutableStateOf(initialSettings.target.phoneNumber) }
+    var kakaoRoomName by remember { mutableStateOf(initialSettings.target.kakaoRoomName) }
+    var kakaoTemplate by remember { mutableStateOf(initialSettings.kakaoMessageTemplate) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(20.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text("벌칙 설정", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                Text(
+                    "연락형 벌칙은 동의한 책임 파트너에게만 보냅니다. 기기 잠금은 공식 lock task 설정이 끝난 경우에만 활성화됩니다.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                OutlinedTextField(
+                    value = partnerName,
+                    onValueChange = { partnerName = it },
+                    label = { Text("책임 파트너 이름") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = phoneNumber,
+                    onValueChange = { phoneNumber = it.filter { ch -> ch.isDigit() || ch == '+' || ch == '-' || ch == ' ' } },
+                    label = { Text("책임 파트너 전화번호") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = kakaoRoomName,
+                    onValueChange = { kakaoRoomName = it },
+                    label = { Text("책임 파트너 카카오톡 방 이름") },
+                    supportingText = { Text("최근에 알림을 한 번 받은 방이어야 바로 전송할 수 있어요.") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = kakaoTemplate,
+                    onValueChange = { kakaoTemplate = it },
+                    label = { Text("카카오 벌칙 메시지 템플릿") },
+                    supportingText = { Text("{partnerName}, {taskTitle}, {taskDescription} 플레이스홀더를 쓸 수 있어요.") },
+                    minLines = 3,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Text("Kakao 상태", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterChip(
+                        selected = runtimeStatus.notificationListenerEnabled,
+                        onClick = { },
+                        label = { Text(if (runtimeStatus.notificationListenerEnabled) "알림 접근 허용" else "알림 접근 필요") },
+                        enabled = false
+                    )
+                    FilterChip(
+                        selected = runtimeStatus.activeKakaoSessions.isNotEmpty(),
+                        onClick = { },
+                        label = { Text(if (runtimeStatus.activeKakaoSessions.isNotEmpty()) "실시간 세션 있음" else "실시간 세션 없음") },
+                        enabled = false
+                    )
+                }
+                if (runtimeStatus.cachedKakaoRooms.isNotEmpty()) {
+                    SelectionContainer {
+                        Text(
+                            "캐시된 방: ${runtimeStatus.cachedKakaoRooms.joinToString(", ")}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    Text(
+                        "아직 캐시된 카카오톡 방이 없어요. 책임 파트너 방 알림을 한 번 받아야 세션이 잡혀요.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = {
+                        context.startActivity(KakaoNotificationAccess.settingsIntent())
+                    }) {
+                        Text("알림 접근 열기")
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+                Text("기기 잠금 상태", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterChip(
+                        selected = lockTaskStatus.isDeviceOwnerApp,
+                        onClick = { },
+                        enabled = false,
+                        label = { Text(if (lockTaskStatus.isDeviceOwnerApp) "기기 소유자 연결됨" else "기기 소유자 미설정") }
+                    )
+                    FilterChip(
+                        selected = lockTaskStatus.isLockTaskPermitted,
+                        onClick = { },
+                        enabled = false,
+                        label = { Text(if (lockTaskStatus.isLockTaskPermitted) "lock task 가능" else "lock task 불가") }
+                    )
+                }
+                Text(
+                    "lock task는 Android 공식 kiosk 모드입니다. 아래 adb 명령은 초기화된 테스트 기기에서만 성공합니다.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                SelectionContainer {
+                    Text(lockTaskStatus.adbProvisioningCommand, style = MaterialTheme.typography.bodySmall)
+                }
+                TextButton(onClick = {
+                    clipboardManager.setText(AnnotatedString(lockTaskStatus.adbProvisioningCommand))
+                    Toast.makeText(context, "adb 명령을 복사했어요.", Toast.LENGTH_SHORT).show()
+                }) {
+                    Text("adb 명령 복사")
+                }
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text("취소")
+                    }
+                    TextButton(onClick = {
+                        onSave(
+                            PenaltySettings(
+                                target = PenaltyTarget(
+                                    partnerName = partnerName.trim(),
+                                    phoneNumber = phoneNumber.trim(),
+                                    kakaoRoomName = kakaoRoomName.trim()
+                                ),
+                                kakaoMessageTemplate = kakaoTemplate.trim().ifBlank { PenaltySettings.DEFAULT_KAKAO_TEMPLATE },
+                                callDialFallbackEnabled = true
+                            )
+                        )
+                    }) {
+                        Text("저장")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/smartpet/todo/ui/components/TaskCard.kt
+++ b/app/src/main/java/com/smartpet/todo/ui/components/TaskCard.kt
@@ -5,15 +5,33 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Delete
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,18 +49,18 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.platform.testTag
 import com.smartpet.todo.data.Task
 import com.smartpet.todo.data.TaskPriority
+import com.smartpet.todo.penalty.TaskPenaltyPresentation
 import com.smartpet.todo.pet.PetBehavior
 import com.smartpet.todo.ui.TossColors
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
+import java.util.Locale
 
-/**
- * Task item card with Toss-style design
- */
 @Composable
 fun TaskCard(
     task: Task,
     nowMillis: Long,
+    penaltyPresentation: TaskPenaltyPresentation,
     onToggleComplete: () -> Unit,
     onVerify: (() -> Unit)?,
     isVerifying: Boolean,
@@ -51,7 +69,7 @@ fun TaskCard(
     modifier: Modifier = Modifier
 ) {
     val interventionLevel = task.getInterventionLevel(nowMillis)
-    
+
     val borderColor by animateColorAsState(
         targetValue = when {
             task.isCompleted -> TossColors.Gray100
@@ -62,13 +80,13 @@ fun TaskCard(
         },
         label = "borderColor"
     )
-    
+
     val checkScale by animateFloatAsState(
         targetValue = if (task.isCompleted) 1f else 0f,
         animationSpec = tween(200),
         label = "checkScale"
     )
-    
+
     Card(
         modifier = modifier
             .fillMaxWidth()
@@ -89,7 +107,6 @@ fun TaskCard(
                 .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Checkbox
             Box(
                 modifier = Modifier
                     .size(48.dp)
@@ -108,25 +125,20 @@ fun TaskCard(
                     modifier = Modifier
                         .size(28.dp)
                         .clip(CircleShape)
-                        .background(
-                            if (task.isCompleted) TossColors.Blue else TossColors.Gray100
-                        ),
+                        .background(if (task.isCompleted) TossColors.Blue else TossColors.Gray100),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         imageVector = Icons.Rounded.Check,
                         contentDescription = null,
                         tint = TossColors.White,
-                        modifier = Modifier
-                            .size(18.dp)
-                            .scale(checkScale)
+                        modifier = Modifier.size(18.dp).scale(checkScale)
                     )
                 }
             }
-            
+
             Spacer(modifier = Modifier.width(16.dp))
-            
-            // Task content
+
             Column(modifier = Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
@@ -143,7 +155,7 @@ fun TaskCard(
                     Spacer(modifier = Modifier.width(8.dp))
                     PriorityBadge(priority = task.priority)
                 }
-                
+
                 if (task.description.isNotBlank()) {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
@@ -154,20 +166,15 @@ fun TaskCard(
                         overflow = TextOverflow.Ellipsis
                     )
                 }
-                
-                // Due date and status
+
                 if (task.dueDate != null) {
                     Spacer(modifier = Modifier.height(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         val dueDateText = formatDueDate(task.dueDate, nowMillis)
                         val urgencyText = if (!task.isCompleted) PetBehavior.getTaskMessage(task, nowMillis) else ""
-                        
-                        Text(
-                            text = dueDateText,
-                            fontSize = 12.sp,
-                            color = TossColors.Gray500
-                        )
-                        
+
+                        Text(text = dueDateText, fontSize = 12.sp, color = TossColors.Gray500)
+
                         if (urgencyText.isNotBlank()) {
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
@@ -187,14 +194,33 @@ fun TaskCard(
 
                 if (task.estimatedMinutes != null) {
                     Spacer(modifier = Modifier.height(6.dp))
+                    Text(text = "예상 ${task.estimatedMinutes}분", fontSize = 12.sp, color = TossColors.Gray500)
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = penaltyPresentation.label,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = TossColors.Blue
+                )
+                Text(
+                    text = penaltyPresentation.detail,
+                    fontSize = 12.sp,
+                    color = TossColors.Gray500,
+                    lineHeight = 16.sp
+                )
+                penaltyPresentation.warning?.let {
+                    Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = "예상 ${task.estimatedMinutes}분",
+                        text = it,
                         fontSize = 12.sp,
-                        color = TossColors.Gray500
+                        color = MaterialTheme.colorScheme.error,
+                        lineHeight = 16.sp
                     )
                 }
             }
-            
+
             Column(
                 horizontalAlignment = Alignment.End,
                 verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -202,9 +228,7 @@ fun TaskCard(
                 if (!task.isCompleted && onVerify != null) {
                     if (isVerifying) {
                         CircularProgressIndicator(
-                            modifier = Modifier
-                                .size(20.dp)
-                                .padding(end = 8.dp),
+                            modifier = Modifier.size(20.dp).padding(end = 8.dp),
                             strokeWidth = 2.dp,
                             color = TossColors.Blue
                         )
@@ -213,19 +237,12 @@ fun TaskCard(
                             onClick = onVerify,
                             contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp)
                         ) {
-                            Text(
-                                text = "인증하기",
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.SemiBold
-                            )
+                            Text(text = "인증하기", fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
                         }
                     }
                 }
 
-                IconButton(
-                    onClick = onDelete,
-                    modifier = Modifier.graphicsLayer(alpha = 0.6f)
-                ) {
+                IconButton(onClick = onDelete, modifier = Modifier.graphicsLayer(alpha = 0.6f)) {
                     Icon(
                         imageVector = Icons.Rounded.Delete,
                         contentDescription = "삭제",
@@ -252,34 +269,16 @@ private fun PriorityBadge(priority: TaskPriority) {
             .background(bg)
             .padding(horizontal = 10.dp, vertical = 4.dp)
     ) {
-        Text(
-            text = label,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.SemiBold,
-            color = fg
-        )
+        Text(text = label, fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = fg)
     }
 }
 
 private fun formatDueDate(timestamp: Long, nowMillis: Long): String {
     val diff = timestamp - nowMillis
-    
     return when {
-        diff < 0 -> {
-            val format = SimpleDateFormat("M월 d일", Locale.KOREA)
-            format.format(Date(timestamp)) + " (지남)"
-        }
-        diff < 60 * 60 * 1000 -> {
-            val minutes = (diff / (60 * 1000)).toInt()
-            "${minutes}분 후"
-        }
-        diff < 24 * 60 * 60 * 1000 -> {
-            val hours = (diff / (60 * 60 * 1000)).toInt()
-            "${hours}시간 후"
-        }
-        else -> {
-            val format = SimpleDateFormat("M월 d일 HH:mm", Locale.KOREA)
-            format.format(Date(timestamp))
-        }
+        diff < 0 -> SimpleDateFormat("M월 d일", Locale.KOREA).format(Date(timestamp)) + " (지남)"
+        diff < 60 * 60 * 1000 -> "${(diff / (60 * 1000)).toInt()}분 후"
+        diff < 24 * 60 * 60 * 1000 -> "${(diff / (60 * 60 * 1000)).toInt()}시간 후"
+        else -> SimpleDateFormat("M월 d일 HH:mm", Locale.KOREA).format(Date(timestamp))
     }
 }

--- a/app/src/main/java/com/smartpet/todo/ui/components/TaskEditor.kt
+++ b/app/src/main/java/com/smartpet/todo/ui/components/TaskEditor.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -54,6 +55,13 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.smartpet.todo.data.Task
 import com.smartpet.todo.data.TaskPriority
+import com.smartpet.todo.penalty.PenaltyDraft
+import com.smartpet.todo.penalty.PenaltyProfile
+import com.smartpet.todo.penalty.PenaltyRuntimeStatus
+import com.smartpet.todo.penalty.PenaltySelectionMode
+import com.smartpet.todo.penalty.PenaltySelector
+import com.smartpet.todo.penalty.PenaltySettings
+import com.smartpet.todo.penalty.PenaltyType
 import com.smartpet.todo.ui.TossColors
 import java.text.SimpleDateFormat
 import java.util.Calendar
@@ -63,6 +71,9 @@ import java.util.Locale
 @Composable
 fun TaskEditorDialog(
     initialTask: Task?,
+    initialPenaltyProfile: PenaltyProfile?,
+    penaltySettings: PenaltySettings,
+    penaltyRuntimeStatus: PenaltyRuntimeStatus,
     onDismiss: () -> Unit,
     onSave: (
         title: String,
@@ -70,7 +81,8 @@ fun TaskEditorDialog(
         dueDate: Long?,
         priority: TaskPriority,
         maxEnforcementLevel: Int,
-        estimatedMinutes: Int?
+        estimatedMinutes: Int?,
+        penaltyDraft: PenaltyDraft
     ) -> Unit
 ) {
     Dialog(onDismissRequest = onDismiss) {
@@ -85,6 +97,9 @@ fun TaskEditorDialog(
         ) {
             TaskEditorContent(
                 initialTask = initialTask,
+                initialPenaltyProfile = initialPenaltyProfile,
+                penaltySettings = penaltySettings,
+                penaltyRuntimeStatus = penaltyRuntimeStatus,
                 onDismiss = onDismiss,
                 onSave = onSave,
                 modifier = Modifier.padding(24.dp)
@@ -92,10 +107,13 @@ fun TaskEditorDialog(
         }
     }
 }
-
 @Composable
+@OptIn(ExperimentalMaterial3Api::class)
 fun TaskEditorContent(
     initialTask: Task?,
+    initialPenaltyProfile: PenaltyProfile?,
+    penaltySettings: PenaltySettings,
+    penaltyRuntimeStatus: PenaltyRuntimeStatus,
     onDismiss: () -> Unit,
     onSave: (
         title: String,
@@ -103,7 +121,8 @@ fun TaskEditorContent(
         dueDate: Long?,
         priority: TaskPriority,
         maxEnforcementLevel: Int,
-        estimatedMinutes: Int?
+        estimatedMinutes: Int?,
+        penaltyDraft: PenaltyDraft
     ) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -115,10 +134,36 @@ fun TaskEditorContent(
     var estimatedMinutesRaw by remember(initialTask?.id) {
         mutableStateOf(initialTask?.estimatedMinutes?.toString().orEmpty())
     }
+    var selectionMode by remember(initialTask?.id) {
+        mutableStateOf(initialPenaltyProfile?.selectionMode ?: PenaltySelectionMode.AUTO)
+    }
+    var manualPenaltyType by remember(initialTask?.id) {
+        mutableStateOf(initialPenaltyProfile?.manualPenaltyType)
+    }
 
     var showDatePicker by remember { mutableStateOf(false) }
-
     val scroll = rememberScrollState()
+
+    val previewTask = remember(title, description, dueDate, priority, maxEnforcementLevel, estimatedMinutesRaw) {
+        Task(
+            id = initialTask?.id ?: "draft",
+            title = title.ifBlank { "임시 제목" },
+            description = description,
+            dueDate = dueDate,
+            priority = priority,
+            maxEnforcementLevel = maxEnforcementLevel.coerceIn(1, 3),
+            estimatedMinutes = estimatedMinutesRaw.toIntOrNull()
+        )
+    }
+    val recommendation = remember(previewTask, penaltySettings, penaltyRuntimeStatus) {
+        PenaltySelector.recommend(previewTask, penaltySettings, penaltyRuntimeStatus)
+    }
+
+    LaunchedEffect(selectionMode) {
+        if (selectionMode == PenaltySelectionMode.AUTO) {
+            manualPenaltyType = null
+        }
+    }
 
     Column(
         modifier = modifier
@@ -239,10 +284,7 @@ fun TaskEditorContent(
                 )
                 OutlinedTextField(
                     value = estimatedMinutesRaw,
-                    onValueChange = { v ->
-                        // Keep it numeric-ish; allow empty.
-                        estimatedMinutesRaw = v.filter { it.isDigit() }.take(4)
-                    },
+                    onValueChange = { v -> estimatedMinutesRaw = v.filter { it.isDigit() }.take(4) },
                     placeholder = { Text("예: 25") },
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(
@@ -274,21 +316,9 @@ fun TaskEditorContent(
         )
         Spacer(modifier = Modifier.height(10.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            PriorityChip(
-                label = "낮음",
-                selected = priority == TaskPriority.LOW,
-                onClick = { priority = TaskPriority.LOW }
-            )
-            PriorityChip(
-                label = "보통",
-                selected = priority == TaskPriority.NORMAL,
-                onClick = { priority = TaskPriority.NORMAL }
-            )
-            PriorityChip(
-                label = "높음",
-                selected = priority == TaskPriority.HIGH,
-                onClick = { priority = TaskPriority.HIGH }
-            )
+            PriorityChip("낮음", priority == TaskPriority.LOW) { priority = TaskPriority.LOW }
+            PriorityChip("보통", priority == TaskPriority.NORMAL) { priority = TaskPriority.NORMAL }
+            PriorityChip("높음", priority == TaskPriority.HIGH) { priority = TaskPriority.HIGH }
         }
 
         Spacer(modifier = Modifier.height(18.dp))
@@ -307,21 +337,70 @@ fun TaskEditorContent(
         )
         Spacer(modifier = Modifier.height(10.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            EnforcementChip(
-                label = "알림",
-                selected = maxEnforcementLevel == 1,
-                onClick = { maxEnforcementLevel = 1 }
+            EnforcementChip("알림", maxEnforcementLevel == 1) { maxEnforcementLevel = 1 }
+            EnforcementChip("조명", maxEnforcementLevel == 2) { maxEnforcementLevel = 2 }
+            EnforcementChip("전원/로봇", maxEnforcementLevel == 3) { maxEnforcementLevel = 3 }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text(
+            text = "미이행 시 벌칙",
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "자동 추천은 작업 성격을 읽고 디바이스 잠금이 역효과인 경우를 피합니다.",
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = selectionMode == PenaltySelectionMode.AUTO,
+                onClick = { selectionMode = PenaltySelectionMode.AUTO },
+                label = { Text("자동 추천") }
             )
-            EnforcementChip(
-                label = "조명",
-                selected = maxEnforcementLevel == 2,
-                onClick = { maxEnforcementLevel = 2 }
+            FilterChip(
+                selected = selectionMode == PenaltySelectionMode.MANUAL,
+                onClick = { selectionMode = PenaltySelectionMode.MANUAL },
+                label = { Text("수동 지정") }
             )
-            EnforcementChip(
-                label = "전원/로봇",
-                selected = maxEnforcementLevel == 3,
-                onClick = { maxEnforcementLevel = 3 }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "자동 추천: ${recommendation.type.toKoreanLabel()} · ${recommendation.reason}",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        recommendation.blockedReason?.let {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
             )
+        }
+
+        if (selectionMode == PenaltySelectionMode.MANUAL) {
+            Spacer(modifier = Modifier.height(10.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ManualPenaltyChipRow(
+                    manualPenaltyType = manualPenaltyType,
+                    onSelect = { manualPenaltyType = it }
+                )
+                manualPenaltyType?.let { selectedType ->
+                    PenaltySelector.blockedReason(selectedType, penaltySettings, penaltyRuntimeStatus)?.let { blocked ->
+                        Text(
+                            text = blocked,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
+            }
         }
 
         Spacer(modifier = Modifier.height(22.dp))
@@ -342,7 +421,6 @@ fun TaskEditorContent(
                 onClick = {
                     val trimmedTitle = title.trim()
                     if (trimmedTitle.isBlank()) return@Button
-
                     val parsedMinutes = estimatedMinutesRaw.toIntOrNull()?.takeIf { it > 0 }?.coerceAtMost(24 * 60)
                     onSave(
                         trimmedTitle,
@@ -350,7 +428,8 @@ fun TaskEditorContent(
                         dueDate,
                         priority,
                         maxEnforcementLevel.coerceIn(1, 3),
-                        parsedMinutes
+                        parsedMinutes,
+                        PenaltyDraft(selectionMode = selectionMode, manualPenaltyType = manualPenaltyType)
                     )
                 },
                 enabled = title.trim().isNotBlank(),
@@ -358,16 +437,9 @@ fun TaskEditorContent(
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
                 shape = RoundedCornerShape(12.dp)
             ) {
-                Icon(
-                    imageVector = Icons.Rounded.Tune,
-                    contentDescription = null,
-                    tint = TossColors.White
-                )
+                Icon(Icons.Rounded.Tune, contentDescription = null, tint = TossColors.White)
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = if (initialTask == null) "추가" else "저장",
-                    fontWeight = FontWeight.SemiBold
-                )
+                Text(text = if (initialTask == null) "추가" else "저장", fontWeight = FontWeight.SemiBold)
             }
         }
     }
@@ -391,11 +463,7 @@ private fun PriorityChip(
     selected: Boolean,
     onClick: () -> Unit
 ) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = { Text(label) }
-    )
+    FilterChip(selected = selected, onClick = onClick, label = { Text(label) })
 }
 
 @Composable
@@ -405,10 +473,37 @@ private fun EnforcementChip(
     selected: Boolean,
     onClick: () -> Unit
 ) {
+    FilterChip(selected = selected, onClick = onClick, label = { Text(label) })
+}
+
+@Composable
+private fun ManualPenaltyChipRow(
+    manualPenaltyType: PenaltyType?,
+    onSelect: (PenaltyType) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            ManualPenaltyChip(PenaltyType.PROOF_REQUIRED, manualPenaltyType, onSelect)
+            ManualPenaltyChip(PenaltyType.DEVICE_LOCK, manualPenaltyType, onSelect)
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            ManualPenaltyChip(PenaltyType.ACCOUNTABILITY_CALL, manualPenaltyType, onSelect)
+            ManualPenaltyChip(PenaltyType.ACCOUNTABILITY_KAKAO, manualPenaltyType, onSelect)
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun ManualPenaltyChip(
+    type: PenaltyType,
+    selectedType: PenaltyType?,
+    onSelect: (PenaltyType) -> Unit
+) {
     FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = { Text(label) }
+        selected = selectedType == type,
+        onClick = { onSelect(type) },
+        label = { Text(type.toKoreanLabel()) }
     )
 }
 
@@ -464,4 +559,11 @@ private fun DueDatePickerDialog(
 private fun formatDate(timestamp: Long): String {
     val format = SimpleDateFormat("M월 d일 (E) HH:mm", Locale.KOREA)
     return format.format(Date(timestamp))
+}
+
+private fun PenaltyType.toKoreanLabel(): String = when (this) {
+    PenaltyType.PROOF_REQUIRED -> "인증 고정"
+    PenaltyType.DEVICE_LOCK -> "앱 고정 잠금"
+    PenaltyType.ACCOUNTABILITY_CALL -> "책임 파트너 전화"
+    PenaltyType.ACCOUNTABILITY_KAKAO -> "책임 파트너 카카오톡"
 }

--- a/app/src/main/java/com/smartpet/todo/viewmodel/TaskViewModel.kt
+++ b/app/src/main/java/com/smartpet/todo/viewmodel/TaskViewModel.kt
@@ -7,6 +7,11 @@ import com.smartpet.todo.alarm.OverdueScheduler
 import com.smartpet.todo.data.RemoteStorage
 import com.smartpet.todo.data.Task
 import com.smartpet.todo.data.TaskPriority
+import com.smartpet.todo.penalty.PenaltyDraft
+import com.smartpet.todo.penalty.PenaltyManager
+import com.smartpet.todo.penalty.PenaltyProfile
+import com.smartpet.todo.penalty.PenaltyRuntimeStatus
+import com.smartpet.todo.penalty.PenaltySettings
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,12 +21,16 @@ import kotlinx.coroutines.launch
 data class TaskUiState(
     val tasks: List<Task> = emptyList(),
     val isLoading: Boolean = false,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val penaltySettings: PenaltySettings = PenaltySettings(),
+    val penaltyProfiles: Map<String, PenaltyProfile> = emptyMap(),
+    val penaltyRuntimeStatus: PenaltyRuntimeStatus = PenaltyRuntimeStatus()
 )
 
 class TaskViewModel(application: Application) : AndroidViewModel(application) {
     private val storage = RemoteStorage()
     private val appContext = application.applicationContext
+    private val penaltyManager = PenaltyManager(appContext)
 
     private val _uiState = MutableStateFlow(TaskUiState())
     val uiState: StateFlow<TaskUiState> = _uiState.asStateFlow()
@@ -31,13 +40,39 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
     fun refresh() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+            val settings = penaltyManager.loadSettings()
+            val profiles = penaltyManager.loadProfiles()
+            val runtimeStatus = penaltyManager.runtimeStatus()
             runCatching { storage.loadTasks() }
                 .onSuccess { tasks ->
-                    _uiState.value = _uiState.value.copy(tasks = tasks, isLoading = false, errorMessage = null)
+                    _uiState.value = _uiState.value.copy(
+                        tasks = tasks,
+                        isLoading = false,
+                        errorMessage = null,
+                        penaltySettings = settings,
+                        penaltyProfiles = profiles,
+                        penaltyRuntimeStatus = runtimeStatus
+                    )
                     OverdueScheduler.scheduleAll(appContext, tasks)
                 }
-                .onFailure(::handleFailure)
+                .onFailure { error ->
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        penaltySettings = settings,
+                        penaltyProfiles = profiles,
+                        penaltyRuntimeStatus = runtimeStatus
+                    )
+                    handleFailure(error)
+                }
         }
+    }
+
+    fun savePenaltySettings(settings: PenaltySettings) {
+        penaltyManager.saveSettings(settings)
+        _uiState.value = _uiState.value.copy(
+            penaltySettings = settings,
+            penaltyRuntimeStatus = penaltyManager.runtimeStatus()
+        )
     }
 
     fun addTask(
@@ -46,7 +81,8 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
         dueDate: Long?,
         priority: TaskPriority,
         maxEnforcementLevel: Int,
-        estimatedMinutes: Int?
+        estimatedMinutes: Int?,
+        penaltyDraft: PenaltyDraft
     ) {
         viewModelScope.launch {
             val normalizedTitle = title.trim()
@@ -65,14 +101,26 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
             )
             runCatching { storage.addTask(task) }
                 .onSuccess { tasks ->
-                    _uiState.value = _uiState.value.copy(tasks = tasks, errorMessage = null)
+                    penaltyManager.saveProfile(
+                        PenaltyProfile(
+                            taskId = task.id,
+                            selectionMode = penaltyDraft.selectionMode,
+                            manualPenaltyType = penaltyDraft.manualPenaltyType
+                        )
+                    )
+                    _uiState.value = _uiState.value.copy(
+                        tasks = tasks,
+                        errorMessage = null,
+                        penaltyProfiles = penaltyManager.loadProfiles(),
+                        penaltyRuntimeStatus = penaltyManager.runtimeStatus()
+                    )
                     OverdueScheduler.scheduleAll(appContext, tasks)
                 }
                 .onFailure(::handleFailure)
         }
     }
 
-    fun updateTask(task: Task) {
+    fun updateTask(task: Task, penaltyDraft: PenaltyDraft) {
         viewModelScope.launch {
             val normalized = normalizeTaskOrNull(task) ?: run {
                 _uiState.value = _uiState.value.copy(errorMessage = "제목을 입력해주세요.")
@@ -80,7 +128,19 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
             }
             runCatching { storage.updateTask(normalized) }
                 .onSuccess { tasks ->
-                    _uiState.value = _uiState.value.copy(tasks = tasks, errorMessage = null)
+                    penaltyManager.saveProfile(
+                        PenaltyProfile(
+                            taskId = normalized.id,
+                            selectionMode = penaltyDraft.selectionMode,
+                            manualPenaltyType = penaltyDraft.manualPenaltyType
+                        )
+                    )
+                    _uiState.value = _uiState.value.copy(
+                        tasks = tasks,
+                        errorMessage = null,
+                        penaltyProfiles = penaltyManager.loadProfiles(),
+                        penaltyRuntimeStatus = penaltyManager.runtimeStatus()
+                    )
                     OverdueScheduler.scheduleAll(appContext, tasks)
                 }
                 .onFailure(::handleFailure)
@@ -92,7 +152,12 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
             OverdueScheduler.cancel(appContext, taskId)
             runCatching { storage.deleteTask(taskId) }
                 .onSuccess { tasks ->
-                    _uiState.value = _uiState.value.copy(tasks = tasks, errorMessage = null)
+                    penaltyManager.clearTrigger(taskId)
+                    _uiState.value = _uiState.value.copy(
+                        tasks = tasks,
+                        errorMessage = null,
+                        penaltyRuntimeStatus = penaltyManager.runtimeStatus()
+                    )
                     OverdueScheduler.scheduleAll(appContext, tasks)
                 }
                 .onFailure(::handleFailure)
@@ -103,7 +168,12 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             runCatching { storage.toggleTaskCompletion(taskId) }
                 .onSuccess { tasks ->
-                    _uiState.value = _uiState.value.copy(tasks = tasks, errorMessage = null)
+                    penaltyManager.clearTrigger(taskId)
+                    _uiState.value = _uiState.value.copy(
+                        tasks = tasks,
+                        errorMessage = null,
+                        penaltyRuntimeStatus = penaltyManager.runtimeStatus()
+                    )
                     OverdueScheduler.scheduleAll(appContext, tasks)
                 }
                 .onFailure(::handleFailure)
@@ -118,7 +188,11 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
             }
             runCatching { storage.upsertTask(normalized) }
                 .onSuccess { tasks ->
-                    _uiState.value = _uiState.value.copy(tasks = tasks, errorMessage = null)
+                    _uiState.value = _uiState.value.copy(
+                        tasks = tasks,
+                        errorMessage = null,
+                        penaltyRuntimeStatus = penaltyManager.runtimeStatus()
+                    )
                     OverdueScheduler.scheduleAll(appContext, tasks)
                 }
                 .onFailure(::handleFailure)

--- a/app/src/main/res/xml/mother_device_admin_receiver.xml
+++ b/app/src/main/res/xml/mother_device_admin_receiver.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies />
+</device-admin>

--- a/app/src/test/java/com/smartpet/todo/penalty/PenaltyLocalStoreTest.kt
+++ b/app/src/test/java/com/smartpet/todo/penalty/PenaltyLocalStoreTest.kt
@@ -1,0 +1,40 @@
+package com.smartpet.todo.penalty
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PenaltyLocalStoreTest {
+
+    @Test
+    fun saveAndLoadSettings_roundTrips() {
+        val root = createTempDir(prefix = "penalty-store-settings-")
+        val store = PenaltyLocalStore(root)
+
+        val settings = PenaltySettings(
+            target = PenaltyTarget(partnerName = "책임", phoneNumber = "010-1234-5678", kakaoRoomName = "책임방"),
+            kakaoMessageTemplate = "[마더] {taskTitle}"
+        )
+        store.saveSettings(settings)
+
+        assertEquals(settings, store.loadSettings())
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun saveProfileAndTrigger_roundTripsAndClears() {
+        val root = createTempDir(prefix = "penalty-store-profile-")
+        val store = PenaltyLocalStore(root)
+
+        val profile = PenaltyProfile(taskId = "task-1", selectionMode = PenaltySelectionMode.MANUAL, manualPenaltyType = PenaltyType.DEVICE_LOCK)
+        store.saveProfile(profile)
+        store.markTriggered(PenaltyTriggerRecord(taskId = "task-1", penaltyType = PenaltyType.DEVICE_LOCK, triggeredAt = 42L))
+
+        assertEquals(PenaltyType.DEVICE_LOCK, store.loadProfiles()["task-1"]?.manualPenaltyType)
+        assertEquals(42L, store.loadTriggers()["task-1"]?.triggeredAt)
+
+        store.clearTriggered("task-1")
+        assertNull(store.loadTriggers()["task-1"])
+        root.deleteRecursively()
+    }
+}

--- a/app/src/test/java/com/smartpet/todo/penalty/PenaltyMessageFormatterTest.kt
+++ b/app/src/test/java/com/smartpet/todo/penalty/PenaltyMessageFormatterTest.kt
@@ -1,0 +1,21 @@
+package com.smartpet.todo.penalty
+
+import com.smartpet.todo.data.Task
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PenaltyMessageFormatterTest {
+
+    @Test
+    fun formatKakaoMessage_replacesSupportedPlaceholders() {
+        val settings = PenaltySettings(
+            target = PenaltyTarget(partnerName = "민수"),
+            kakaoMessageTemplate = "[마더] {partnerName}: {taskTitle} / {taskDescription}"
+        )
+        val task = Task(title = "운동", description = "러닝 30분")
+
+        val formatted = PenaltyMessageFormatter.formatKakaoMessage(settings, task)
+
+        assertEquals("[마더] 민수: 운동 / 러닝 30분", formatted)
+    }
+}

--- a/app/src/test/java/com/smartpet/todo/penalty/PenaltySelectorTest.kt
+++ b/app/src/test/java/com/smartpet/todo/penalty/PenaltySelectorTest.kt
@@ -1,0 +1,56 @@
+package com.smartpet.todo.penalty
+
+import com.smartpet.todo.data.Task
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PenaltySelectorTest {
+
+    @Test
+    fun classify_deviceRequiredTask_returnsDeviceRequired() {
+        val category = PenaltySelector.classify(Task(title = "코딩 완료하기", description = "리팩토링 마무리"))
+        assertEquals(TaskCategory.DEVICE_REQUIRED, category)
+    }
+
+    @Test
+    fun recommend_photoVerifiableTask_prefersProofRequired() {
+        val recommendation = PenaltySelector.recommend(
+            task = Task(title = "운동 인증", description = "러닝 30분"),
+            settings = PenaltySettings(),
+            runtimeStatus = PenaltyRuntimeStatus()
+        )
+
+        assertEquals(TaskCategory.PHOTO_VERIFIABLE, recommendation.category)
+        assertEquals(PenaltyType.PROOF_REQUIRED, recommendation.type)
+    }
+
+    @Test
+    fun recommend_genericTask_usesLockWhenReady() {
+        val recommendation = PenaltySelector.recommend(
+            task = Task(title = "회고 작성"),
+            settings = PenaltySettings(target = PenaltyTarget(partnerName = "민수")),
+            runtimeStatus = PenaltyRuntimeStatus(isLockTaskPermitted = true)
+        )
+
+        assertEquals(PenaltyType.DEVICE_LOCK, recommendation.type)
+    }
+
+    @Test
+    fun resolve_manualOverride_keepsManualTypeAndWarnsWhenUnavailable() {
+        val resolution = PenaltySelector.resolve(
+            task = Task(title = "산책"),
+            profile = PenaltyProfile(
+                taskId = "task-1",
+                selectionMode = PenaltySelectionMode.MANUAL,
+                manualPenaltyType = PenaltyType.ACCOUNTABILITY_KAKAO
+            ),
+            settings = PenaltySettings(),
+            runtimeStatus = PenaltyRuntimeStatus(notificationListenerEnabled = false)
+        )
+
+        assertEquals(PenaltyType.ACCOUNTABILITY_KAKAO, resolution.selectedType)
+        assertTrue(resolution.usingManualOverride)
+        assertEquals("책임 파트너 카카오톡 방 이름을 먼저 입력하세요.", resolution.blockedReason)
+    }
+}

--- a/docs/changes/2026-04-13-punishment-system.md
+++ b/docs/changes/2026-04-13-punishment-system.md
@@ -1,0 +1,44 @@
+# 2026-04-13: Android Punishment System
+
+## 배경
+기존 앱은 overdue 시 경고 화면과 사진 인증만 제공했고, 사용자가 받을 명시적 벌칙과 설정 화면이 없었습니다.
+
+## 목표
+- task별 벌칙 선택 시스템 추가
+- 자동 추천과 수동 override 지원
+- Kakao/전화/lock-task/인증 고정 벌칙 지원
+- README, runbook, CI 정비
+
+## 변경 내용
+- `penalty/` 패키지 추가: 모델, selector, 로컬 store, manager
+- `kakao/` 패키지 추가: notification listener, 세션 캐시, sender
+- `admin/` 패키지 추가: DeviceAdminReceiver, lock task controller
+- Task editor에 벌칙 선택 UI 추가
+- 메인 화면에 벌칙 설정 다이얼로그와 준비 상태 카드 추가
+- overdue activity를 non-dismissible proof gate로 재구성
+- AndroidManifest에 `CALL_PHONE`, notification listener, device-admin receiver 추가
+
+## 설계 이유
+- task 본문은 기존 webhook을 유지하고, 벌칙 메타데이터는 로컬 sidecar로 분리했습니다.
+- 코딩/공부처럼 디바이스가 필요한 목표는 자동 selector가 잠금형 벌칙을 피합니다.
+- lock task는 공식 Android Device Owner 경로만 허용해 허위 보장을 피했습니다.
+
+## 영향 범위
+- Android 앱 전체 UI 흐름
+- overdue punishment 처리
+- 로컬 설정/상태 관리
+
+## 검증 방법
+- `./gradlew test`
+- `./gradlew :app:assembleDebug`
+- `./gradlew connectedAndroidTest` (온라인 디바이스 필요)
+
+## 남아 있는 한계
+- 벌칙 메타데이터는 로컬 전용이라 기기 간 동기화되지 않습니다.
+- Kakao 벌칙은 최근 알림 세션이 있어야 즉시 전송됩니다.
+- lock task는 Device Owner provisioning이 없으면 실행되지 않습니다.
+
+## 후속 과제
+- emulator/manual scenario 자동화
+- Kakao 세션 진단 UI 강화
+- local sidecar 복원/정리 정책 개선

--- a/docs/runbooks/android-device-owner-lock-task.md
+++ b/docs/runbooks/android-device-owner-lock-task.md
@@ -1,0 +1,29 @@
+# Android Device Owner / Lock Task 준비
+
+## 왜 필요한가
+`앱 고정 잠금` 벌칙은 Android 공식 lock task mode를 사용합니다. 이 모드는 Device Owner 또는 allowlist 설정이 없는 일반 앱에서는 진짜로 강제되지 않습니다.
+
+## 전제 조건
+- 초기화된 테스트 디바이스 또는 전용 기기
+- ADB 연결
+- 앱이 설치되어 있어야 함
+
+## 기본 명령
+
+```bash
+adb shell dpm set-device-owner com.smartpet.todo/com.smartpet.todo.admin.MotherDeviceAdminReceiver
+```
+
+## 확인 방법
+- 앱 설정 > 벌칙 설정에서
+  - `기기 소유자 연결됨`
+  - `lock task 가능`
+  상태가 모두 보이면 준비 완료입니다.
+
+## 실패 원인
+- 이미 계정이 연결된 일반 사용자 디바이스
+- 기존 Device Owner가 남아 있는 디바이스
+- receiver/component 이름 오타
+
+## 해제 / 재설정 주의
+Device Owner는 기기 정책에 큰 영향을 줍니다. 일반 사용자 기기에는 적용하지 말고, 테스트용 디바이스에서만 사용하세요.


### PR DESCRIPTION
## 배경
- overdue task가 단순 경고만 제공하던 상태에서 실제 벌칙 설정과 책임 파트너 개입이 필요했습니다.
- Android 앱에 README, docs, CI도 비어 있었습니다.

## 문제 또는 목표
- task별 벌칙 시스템 추가
- 자동 추천 + 수동 override 지원
- Kakao/전화/lock task/인증 고정 벌칙 구현
- 문서와 CI 정비

## 변경 내용 요약
- `penalty/`, `kakao/`, `admin/` 패키지 추가
- task editor와 main screen에 벌칙 설정 UI 추가
- overdue activity를 non-dismissible proof gate로 재구성
- Device Owner lock task 경로 추가
- Android README, runbook, changes doc, CI workflow 추가

## 설계 판단 이유
- remote task payload는 유지하고, 벌칙 메타데이터는 로컬 sidecar JSON으로 분리했습니다.
- device-required goal은 자동 selector가 잠금형 벌칙을 피합니다.
- lock task는 공식 준비가 끝난 경우에만 활성화합니다.

## 테스트 결과
- `./gradlew test` ✅
- `./gradlew :app:assembleDebug` ✅
- `./gradlew lint` ✅
- `./gradlew connectedAndroidTest` ❌ 오프라인 에뮬레이터만 감지되어 실제 기기 없음

## 실제 사용자 시나리오 검증 결과
- task CRUD + 벌칙 저장은 Compose/UI + unit build 기준으로 검증
- overdue proof gate는 activity compile/lint와 permission checks 기준으로 검증
- instrumentation smoke는 오프라인 emulator로 차단

## 문서 반영 여부
- README 추가
- `docs/changes/2026-04-13-punishment-system.md`
- `docs/runbooks/android-device-owner-lock-task.md`
- AGENTS 갱신

## 영향 범위
- Android app UI, overdue flow, local storage, notification listener, device owner setup

## 리스크 / 남은 과제
- Kakao 세션은 최근 알림이 없는 방에서는 즉시 전송되지 않을 수 있음
- 벌칙 metadata는 현재 로컬 전용
- connectedAndroidTest는 온라인 디바이스에서 추가 확인 필요
